### PR TITLE
feat: add GoReleaser for automated releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,11 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      major: ${{ steps.release.outputs.major }}
+      minor: ${{ steps.release.outputs.minor }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -29,3 +34,26 @@ jobs:
           git tag -f v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} ${{ steps.release.outputs.tag_name }}
           git push origin v${{ steps.release.outputs.major }} --force
           git push origin v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} --force
+
+  goreleaser:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: glowm
+    main: ./cmd/glowm
+    binary: glowm
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - id: glowm
+    formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: 'checksums.txt'
+
+changelog:
+  use: github-native
+
+brews:
+  - repository:
+      owner: atani
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/atani/glowm"
+    description: "Glow-like Markdown CLI with Mermaid diagrams (iTerm2/Kitty inline images + PDF)"
+    license: "MIT"
+    commit_author:
+      name: github-actions[bot]
+      email: github-actions[bot]@users.noreply.github.com
+    install: |
+      bin.install "glowm"
+    test: |
+      system "#{bin}/glowm", "--version"

--- a/cmd/glowm/main.go
+++ b/cmd/glowm/main.go
@@ -15,14 +15,27 @@ import (
 	"github.com/atani/glowm/internal/terminal"
 )
 
+// Version information (set by goreleaser ldflags)
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
 	var (
-		width    = flag.Int("w", 0, "word wrap width")
-		style    = flag.String("s", "auto", "style name or JSON path")
-		usePager = flag.Bool("p", false, "page output")
-		pdf      = flag.Bool("pdf", false, "output mermaid diagrams as PDF to stdout")
+		width       = flag.Int("w", 0, "word wrap width")
+		style       = flag.String("s", "auto", "style name or JSON path")
+		usePager    = flag.Bool("p", false, "page output")
+		pdf         = flag.Bool("pdf", false, "output mermaid diagrams as PDF to stdout")
+		showVersion = flag.Bool("version", false, "show version information")
 	)
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("glowm %s (commit: %s, built: %s)\n", version, commit, date)
+		return
+	}
 
 	md, err := input.Read(flag.Args())
 	if err != nil {


### PR DESCRIPTION
## Summary
- GoReleaserを追加してリリース時にhomebrew-tapを自動更新
- `--version`フラグを追加

## Setup Required
リポジトリのSecretsに`HOMEBREW_TAP_GITHUB_TOKEN`を設定してください。

## Test plan
- [ ] `go build ./cmd/glowm && ./glowm --version` でビルド確認
- [ ] マージ後、Release PleaseのPRをマージしてリリースを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)