### PR TITLE
fix: add fetch-tags to checkout for tag creation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,8 @@ jobs:
 
       - uses: actions/checkout@v6
         if: ${{ steps.release.outputs.release_created }}
+        with:
+          fetch-tags: true
 
       - name: Tag major and minor versions
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary
- `actions/checkout` doesn't fetch tags by default
- The "Tag major and minor versions" step was failing because it couldn't resolve the release tag
- Added `fetch-tags: true` to fix this issue

## Test plan
- [ ] Verify PR merges successfully
- [ ] Next release should create major/minor tags correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)