### PR TITLE
ci: trigger CI on release-please branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - release-please--branches--main
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Release Please PRs don't trigger `pull_request` events (GITHUB_TOKEN limitation)
- Added `release-please--branches--main` to push triggers so CI runs on Release Please PRs

## Test plan
- [ ] Merge this PR
- [ ] PR #10 should have CI status reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)