### PR TITLE
Fix Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Get PR
+      - name: Get PR info
         id: pr
         uses: actions/github-script@v8
         with:
@@ -24,15 +24,7 @@ jobs:
               core.setFailed('No PR found for workflow_run');
               return;
             }
-            const pr = prs[0];
-            core.setOutput('url', pr.html_url);
-            core.setOutput('number', pr.number);
-
-      - name: Ensure Dependabot PR
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const prNumber = ${{ steps.pr.outputs.number }};
+            const prNumber = prs[0].number;
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -40,10 +32,12 @@ jobs:
             });
             if (pr.user.login !== 'dependabot[bot]') {
               core.setFailed(`Not a Dependabot PR: ${pr.user.login}`);
+              return;
             }
+            core.setOutput('number', prNumber);
 
       - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"
         env:
-          PR_URL: ${{ steps.pr.outputs.url }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
           GH_TOKEN: ${{ secrets.DEPENDABOT_AUTO_MERGE_TOKEN }}


### PR DESCRIPTION
## Summary
- `workflow_run.pull_requests` に `html_url` が存在しないため `PR_URL` が空になっていたバグを修正
- `gh pr merge` に `--repo` フラグを追加し、checkout なしで動作するように修正
- PR取得とDependabotチェックを1ステップに統合

## 根本原因
`workflow_run.pull_requests[].html_url` は GitHub API に存在しないフィールド。  
さらに `gh pr merge` がリポジトリ情報なしで実行されて `fatal: not a git repository` エラーが発生していた。

## Test plan
- [x] Dependabot PR が作成された際、CI パス後に auto-merge が有効化される