### PR TITLE
fix(ci): auto-fix Auto-merge Dependabot PRs failure

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -31,11 +31,11 @@ jobs:
               pull_number: prNumber,
             });
             if (pr.user.login !== 'dependabot[bot]') {
-              core.setFailed(`Not a Dependabot PR: ${pr.user.login}`);
+              core.info(`Skipping: not a Dependabot PR (author: ${pr.user.login})`);
               return;
             }
             if (!pr.head.ref.startsWith('dependabot/')) {
-              core.setFailed(`Branch does not match dependabot pattern: ${pr.head.ref}`);
+              core.info(`Skipping: branch does not match dependabot pattern: ${pr.head.ref}`);
               return;
             }
             core.setOutput('number', prNumber);


### PR DESCRIPTION
## Automated CI Fix

**Workflow**: Auto-merge Dependabot PRs
**Failed Run**: https://github.com/atani/glowm/actions/runs/23372722008

### What was fixed
Dependabot以外のPRで `core.setFailed()` の代わりに `core.info()` を使用し、非Dependabot PRを失敗ではなくスキップとして扱うように修正。

---
*Auto-generated by [ci-autofix](https://github.com/atani/homelab/tree/main/ci-autofix). Please review before merging.*
