### PR TITLE
fix(ci): Go 1.24 -> 1.25 に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@v2


### PR DESCRIPTION
## Summary
- golang.org/x/term v0.41.0 が `go >= 1.25.0` を要求するため、CI の Go バージョンを 1.25 に更新

## Test plan
- [ ] CI の build ジョブが通ることを確認
- [ ] マージ後 #21 の CI が通ることを確認