### PR TITLE
fix(ci): update Go version from 1.25 to 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@v2


### PR DESCRIPTION
## Summary
- chromedp 0.15.0 (PR #27) requires `go >= 1.26`
- Update CI Go version to match

## Test plan
- [ ] CI passes with Go 1.26