### PR TITLE
fix(ci): auto-fix go_modules in /. - Update #1347130734 failure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,13 @@ updates:
       - "dependencies"
       - "go"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "github.com/charmbracelet/glamour/v2"
+        versions: ["2.0.0"]
+        # Upstream renamed the published module path to charm.land/glamour/v2,
+        # so Dependabot's direct update attempt currently fails with
+        # go_module_path_mismatch. Ignore the first stable release until the
+        # codebase is migrated to the new import path.
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Automated CI Fix

**Workflow**: go_modules in /. - Update #1347130734
**Failed Run**: https://github.com/atani/glowm/actions/runs/25318474663

### What was fixed
Ignored `github.com/charmbracelet/glamour/v2` version `2.0.0` in Dependabot because the upstream stable release renamed the module path to `charm.land/glamour/v2`, which currently makes Dependabot fail with `go_module_path_mismatch` before a repo-wide import migration is done.

---
*Auto-generated by OpenClaw ci-autofix skill. Please review before merging.*
