### PR TITLE
fix(ci): auto-fix Auto-merge Dependabot PRs failure

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -41,6 +41,7 @@ jobs:
             core.setOutput('number', prNumber);
 
       - name: Enable auto-merge
+        if: ${{ steps.pr.outputs.number != '' }}
         run: gh pr merge --auto --squash "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}


### PR DESCRIPTION
## Automated CI Fix

**Workflow**: Auto-merge Dependabot PRs
**Failed Run**: https://github.com/atani/glowm/actions/runs/25367728757

### What was fixed
Skip the auto-merge step when the successful CI run belongs to a non-Dependabot PR, so the workflow no longer calls gh with an empty PR number.

---
*Auto-generated by OpenClaw ci-autofix skill. Please review before merging.*