### PR TITLE
fix(ci): auto-fix go_modules in /. - Update #1372506406 failure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,10 +17,9 @@ updates:
     open-pull-requests-limit: 5
     ignore:
       - dependency-name: "github.com/charmbracelet/glamour/v2"
-        versions: ["2.0.0"]
         # Upstream renamed the published module path to charm.land/glamour/v2,
-        # so Dependabot's direct update attempt currently fails with
-        # go_module_path_mismatch. Ignore the first stable release until the
+        # and Dependabot's direct update attempt now fails with
+        # go_module_path_mismatch. Ignore this legacy module path until the
         # codebase is migrated to the new import path.
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Automated CI Fix

**Workflow**: go_modules in /. - Update #1372506406
**Failed Run**: https://github.com/atani/glowm/actions/runs/26053694989

### What was fixed
Ignored the legacy github.com/charmbracelet/glamour/v2 module path entirely in Dependabot until glowm migrates to charm.land/glamour/v2, so Dependabot stops retrying the known go_module_path_mismatch failure.

---
*Auto-generated by OpenClaw ci-autofix skill. Please review before merging.*