### PR TITLE
Prepare glowm for global OSS launch

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,21 @@
+title: "[Idea]: "
+labels: []
+body:
+  - type: textarea
+    id: workflow
+    attributes:
+      label: What are you using glowm for?
+      description: ADRs, READMEs, runbooks, Mermaid diagrams, PDF export, terminal preview, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: idea
+    attributes:
+      label: What would make the workflow better?
+    validations:
+      required: true
+  - type: input
+    id: terminal
+    attributes:
+      label: Terminal / environment
+      placeholder: "iTerm2, Kitty, Ghostty, tmux, SSH, ..."

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,46 @@
+name: Bug report
+description: Report a problem with glowm
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Terminal rendering issues are much easier to fix with environment details.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the problem and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      description: Include a minimal Markdown/Mermaid example if possible.
+      placeholder: |
+        1. Run `glowm ...`
+        2. See ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: glowm version
+      placeholder: "glowm --version"
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: "macOS 15, Ubuntu 24.04, Windows 11, ..."
+  - type: input
+    id: terminal
+    attributes:
+      label: Terminal
+      placeholder: "iTerm2, Kitty, Ghostty, WezTerm, tmux, SSH, ..."
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions and ideas
+    url: https://github.com/atani/glowm/discussions
+    about: Use Discussions for open-ended ideas once Discussions are enabled.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Suggest an idea for glowm
+title: "feature: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What workflow or limitation should this improve?
+      placeholder: "I want to read/export/share Markdown docs with..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like glowm to do?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Markdown rendering
+        - Mermaid rendering
+        - PDF export
+        - Terminal image support
+        - Pager / navigation
+        - Installation / packaging
+        - Documentation
+        - Other
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Testing
+
+<!-- Paste commands and results, for example: go test ./... -->
+
+## Screenshots / terminal notes
+
+<!-- If this affects rendering, include terminal app/version and screenshots if useful. -->
+
+## Checklist
+
+- [ ] I updated docs for user-facing changes
+- [ ] I ran `go test ./...`
+- [ ] I considered terminal compatibility: iTerm2 / Kitty / Ghostty / tmux / SSH

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 /docs/*
 !/docs/README-demo.png
+!/docs/*.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Code of Conduct
+
+This project follows the Contributor Covenant Code of Conduct.
+
+## Our pledge
+
+We pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Being respectful and constructive
+- Welcoming newcomers and different perspectives
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior include:
+
+- Harassment, trolling, or insulting comments
+- Public or private harassment
+- Publishing others' private information without permission
+- Other conduct that could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Project maintainers are responsible for clarifying and enforcing standards of acceptable behavior and may remove, edit, or reject comments, commits, issues, and pull requests that do not align with this Code of Conduct.
+
+Instances of abusive behavior may be reported through the maintainer's GitHub profile.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to glowm
+
+Thanks for your interest in contributing to glowm.
+
+## Development setup
+
+Requirements:
+
+- Go, matching the version in `go.mod`
+- Chrome or Chromium for Mermaid rendering and PDF-related tests
+
+Run tests:
+
+```bash
+go test ./...
+```
+
+Run the CLI locally:
+
+```bash
+go run ./cmd/glowm README.md
+```
+
+## Useful areas for contributions
+
+- Terminal image compatibility: iTerm2, Kitty, Ghostty, tmux, SSH
+- Mermaid rendering edge cases
+- Markdown rendering quality
+- PDF export behavior
+- Packaging and installation improvements
+- Documentation examples and demo material
+
+## Pull request guidelines
+
+- Keep changes focused and small when possible
+- Add or update tests for behavior changes
+- Update README/docs for user-facing changes
+- Run `go test ./...` before opening a PR
+
+## Reporting terminal compatibility issues
+
+Please include:
+
+- OS and version
+- Terminal app and version
+- Whether you are using tmux, SSH, or a remote dev container
+- Output of `glowm --version`
+- A minimal Markdown/Mermaid example that reproduces the issue

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Akira Taniwaki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,38 +1,100 @@
 # glowm
 
-A [Glow](https://github.com/charmbracelet/glow)-like Markdown CLI with Mermaid rendering for iTerm2/Kitty/Ghostty and PDF output.
+**Read Markdown architecture docs in your terminal — with Mermaid diagrams rendered inline.**
 
-![glowm demo](docs/demo.gif)
+`glowm` is a terminal-first Markdown viewer for developers who keep design docs, ADRs, and diagrams next to the code. It renders Markdown beautifully in the terminal, displays Mermaid diagrams inline on modern terminals like iTerm2, Kitty, and Ghostty, and can export diagrams to PDF when you need to share them outside the terminal.
+
+> Stop opening a browser just to preview Mermaid diagrams in Markdown.
+
 ![glowm demo screenshot](docs/README-demo.png)
 
-## Usage
+## Why glowm?
+
+Many engineering teams keep architecture notes, runbooks, ADRs, and design documents in Markdown. Mermaid makes those docs more useful, but most terminal Markdown viewers leave Mermaid blocks as plain code.
+
+`glowm` keeps the whole workflow in your terminal:
+
+- **Inline Mermaid diagrams** on iTerm2, Kitty, and Ghostty
+- **PDF export** for Mermaid diagrams when you need an artifact
+- **Pager-first reading** for long documentation files
+- **STDIN support** for piping generated docs or command output
+- **Glow-like Markdown rendering** with familiar terminal ergonomics
+
+## Perfect for
+
+- Reading architecture docs and ADRs without leaving the terminal
+- Previewing Mermaid-heavy README files before committing
+- Reviewing documentation in SSH sessions or terminal-only workflows
+- Exporting diagrams from Markdown docs to PDF
+- Teams that prefer docs-as-code over browser-only documentation tools
+
+## Install
+
+### Homebrew
+
+```bash
+brew tap atani/tap
+brew install glowm
+```
+
+### Go
+
+```bash
+go install github.com/atani/glowm/cmd/glowm@latest
+```
+
+## Quick start
 
 ```bash
 # Render Markdown to ANSI output
-./glowm README.md
+glowm README.md
 
 # Read from STDIN
-cat README.md | ./glowm -
+cat README.md | glowm -
 
 # Export Mermaid diagrams to PDF
-./glowm --pdf README.md > diagram.pdf
+glowm --pdf README.md > diagrams.pdf
 ```
+
+## Mermaid rendering
+
+When stdout is a supported terminal, Mermaid code blocks are rendered inline as images:
+
+- iTerm2
+- Kitty
+- Ghostty
+
+On other terminals, Mermaid blocks gracefully fall back to code blocks.
+
+Chrome or Chromium is required for Mermaid rendering and PDF export.
+
+## Comparison
+
+| Feature | glowm | Glow | Browser preview | VS Code preview |
+| --- | --- | --- | --- | --- |
+| Terminal Markdown reading | ✅ | ✅ | ❌ | ❌ |
+| Inline Mermaid diagrams in terminal | ✅ | ❌ | ❌ | ❌ |
+| Mermaid PDF export | ✅ | ❌ | Varies | Varies |
+| Works with STDIN / pipes | ✅ | ✅ | ❌ | ❌ |
+| Good for SSH / terminal-only workflows | ✅ | ✅ | ❌ | ❌ |
+| Docs stay close to the codebase | ✅ | ✅ | ✅ | ✅ |
 
 ## Options
 
 - `-w` Word wrap width
-- `-s` Style name (dark/light/notty/auto) or JSON style path
-- `-p` Force pager output (overrides `--no-pager`)
-- `--no-pager` Disable default pager (pager is on by default for TTY)
+- `-s` Style name (`dark`, `light`, `notty`, `auto`) or JSON style path
+- `-p` Force pager output, overriding `--no-pager`
+- `--no-pager` Disable default pager; pager is on by default for TTY
 - `--pdf` Export Mermaid diagrams to PDF via stdout
+- `--version` Show version information
 
 ## Config
 
-glowm reads the config file from the OS-specific user config directory:
+`glowm` reads the config file from the OS-specific user config directory:
 
 - **macOS**: `~/Library/Application Support/glowm/config.json`
-- **Linux**: `~/.config/glowm/config.json` (or `$XDG_CONFIG_HOME/glowm/config.json`)
-- **Windows**: `%AppData%\glowm\config.json`
+- **Linux**: `~/.config/glowm/config.json` or `$XDG_CONFIG_HOME/glowm/config.json`
+- **Windows**: `%AppData%\\glowm\\config.json`
 
 Example:
 
@@ -46,21 +108,22 @@ Example:
 
 ## Requirements
 
-- Go
-- Chrome/Chromium (required for Mermaid rendering and PDF export)
+- Go, when installing from source
+- Chrome or Chromium, required for Mermaid rendering and PDF export
+- A terminal with image support for inline diagrams: iTerm2, Kitty, or Ghostty
 
-## Mermaid rendering
+## Launch notes
 
-- iTerm2 / Kitty / Ghostty: Mermaid diagrams are rendered inline as images
-- Other terminals: Mermaid blocks are shown as code
+Maintainers can use [`docs/launch-kit.md`](docs/launch-kit.md) for English launch copy and [`docs/global-launch-checklist.md`](docs/global-launch-checklist.md) for repository metadata and posting order.
 
-## Install (Homebrew)
+## Contributing
 
-```bash
-brew tap atani/tap
-brew install glowm
-```
+Issues and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for development notes.
 
 ## Support
 
 [![GitHub Sponsors](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ea4aaa?logo=github)](https://github.com/sponsors/atani)
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please do not open a public GitHub issue for security vulnerabilities.
+
+Instead, report the issue privately through GitHub Security Advisories if available, or contact the maintainer through the GitHub profile linked from this repository.
+
+Please include:
+
+- A description of the issue
+- Steps to reproduce
+- Impact and affected versions, if known
+- Any suggested mitigation
+
+## Scope
+
+Security reports are especially useful for:
+
+- Unsafe handling of local files or paths
+- Unexpected execution or browser automation behavior
+- Malicious Markdown/Mermaid input that causes unintended effects
+- Dependency vulnerabilities that affect normal glowm usage
+
+## Non-goals
+
+Rendering untrusted Markdown may involve browser-based Mermaid rendering. glowm should not be treated as a sandbox for hostile documents unless explicitly documented otherwise.

--- a/docs/global-launch-checklist.md
+++ b/docs/global-launch-checklist.md
@@ -1,0 +1,73 @@
+# Global launch checklist
+
+This checklist is for maintainers preparing glowm for English-speaking developer communities.
+
+## Repository metadata
+
+Recommended GitHub settings:
+
+- Description: `A terminal Markdown viewer for architecture docs, with inline Mermaid diagrams and PDF export.`
+- Homepage: `https://github.com/atani/glowm`
+- Enable Discussions
+- Topics:
+  - `markdown`
+  - `mermaid`
+  - `terminal`
+  - `cli`
+  - `tui`
+  - `golang`
+  - `developer-tools`
+  - `documentation`
+  - `architecture`
+  - `adr`
+  - `iterm2`
+  - `kitty`
+  - `ghostty`
+  - `pdf`
+  - `glow`
+
+## Before posting
+
+- README explains the Mermaid-in-terminal value in the first screen
+- Demo GIF is visible near the top
+- Install commands are visible and short
+- Chrome/Chromium requirement is documented
+- Comparison table explains why glowm is different from Glow, browser preview, and editor preview
+- License, contributing guide, security policy, code of conduct, issue templates, and PR template exist
+- Latest release assets are available
+- `go test ./...` and CI are green
+
+## Launch order
+
+Use small, relevant communities first. Improve wording based on feedback before posting to larger communities.
+
+1. `r/commandline`
+2. `r/golang`
+3. Kitty / Ghostty / iTerm2 user communities
+4. Mermaid / docs-as-code communities
+5. Lobsters
+6. Show HN
+7. Product Hunt or broader launch surfaces, only if the project has a polished demo video
+
+## Post timing
+
+- Avoid posting everywhere on the same day
+- Post when you can reply for 2-4 hours
+- Treat early comments as product research, not just promotion
+- Update README wording if the same question appears repeatedly
+
+## Response principles
+
+- Lead with the browser-switching pain for Mermaid previews
+- Say glowm is Glow-like, but Mermaid-focused
+- Be explicit about supported terminal image protocols
+- Ask for compatibility reports from terminal users
+- Thank users who report install issues or terminal rendering edge cases
+
+## Metrics to watch
+
+- GitHub stars after each post
+- Clones and Homebrew installs after each post
+- Questions about Chrome/Chromium requirement
+- Terminal compatibility reports: iTerm2, Kitty, Ghostty, tmux, SSH
+- Requests for additional output formats or diagrams

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -1,0 +1,117 @@
+# glowm launch kit
+
+Use this when introducing glowm to English-speaking developer communities.
+
+## One-line positioning
+
+A terminal Markdown viewer for architecture docs, with inline Mermaid diagrams and PDF export.
+
+## Short description
+
+`glowm` is a Glow-like Markdown CLI for terminal-first documentation workflows. It renders Markdown in the terminal, displays Mermaid diagrams inline on iTerm2, Kitty, and Ghostty, and can export diagrams to PDF.
+
+## Core message
+
+Stop opening a browser just to preview Mermaid diagrams in Markdown. If your architecture docs, ADRs, runbooks, and READMEs live next to your code, glowm lets you read them from the terminal.
+
+## Show HN
+
+Title:
+
+```text
+Show HN: glowm – view Markdown with inline Mermaid diagrams in your terminal
+```
+
+Body:
+
+```text
+Hi HN,
+
+I built glowm, a terminal Markdown viewer for architecture docs and Mermaid-heavy READMEs.
+
+It is inspired by Glow, but adds Mermaid rendering for terminals that support inline images, including iTerm2, Kitty, and Ghostty. It can also export Mermaid diagrams to PDF.
+
+Why I built it: I keep design docs and ADRs next to code, and I wanted to preview Mermaid diagrams without switching to a browser or editor preview pane.
+
+Install:
+  brew tap atani/tap
+  brew install glowm
+
+Or:
+  go install github.com/atani/glowm/cmd/glowm@latest
+
+GitHub: https://github.com/atani/glowm
+
+I would love feedback from people who keep architecture docs, ADRs, or Mermaid diagrams in Git.
+```
+
+## Reddit: r/commandline
+
+Title:
+
+```text
+I built a terminal Markdown viewer that renders Mermaid diagrams inline
+```
+
+Body:
+
+```text
+I built glowm, a terminal-first Markdown viewer for docs-as-code workflows.
+
+It renders Markdown in the terminal and can render Mermaid diagrams inline on iTerm2, Kitty, and Ghostty. It also supports exporting Mermaid diagrams to PDF.
+
+The use case is simple: if your READMEs, ADRs, runbooks, or architecture docs live in Git and include Mermaid diagrams, you can preview them without opening a browser or editor preview.
+
+GitHub: https://github.com/atani/glowm
+
+I would appreciate feedback from people who live in the terminal or maintain Markdown-heavy repos.
+```
+
+## Reddit: r/golang
+
+Title:
+
+```text
+I built glowm, a Go CLI for reading Markdown docs with inline Mermaid diagrams
+```
+
+Body:
+
+```text
+I built glowm in Go: a Markdown CLI for terminal-first documentation workflows.
+
+It is Glow-like, but it renders Mermaid diagrams inline on modern terminals such as iTerm2, Kitty, and Ghostty, and can export Mermaid diagrams to PDF.
+
+Repo: https://github.com/atani/glowm
+
+I would especially appreciate feedback on packaging, terminal image support, and cross-platform behavior.
+```
+
+## X / Bluesky
+
+```text
+I built glowm: a terminal Markdown viewer for architecture docs.
+
+It renders Mermaid diagrams inline in iTerm2, Kitty, and Ghostty, and can export diagrams to PDF.
+
+Useful if your READMEs, ADRs, or design docs live next to your code.
+
+https://github.com/atani/glowm
+```
+
+## Launch order
+
+1. r/commandline
+2. r/golang
+3. terminal-specific communities: Kitty, Ghostty, iTerm2 users
+4. Mermaid / docs-as-code communities
+5. Lobsters
+6. Show HN
+
+## Response principles
+
+- Lead with the pain: switching to a browser just to preview Mermaid diagrams.
+- Ask for terminal compatibility feedback.
+- Do not describe glowm as a full documentation platform.
+- Be clear that Chrome/Chromium is required for Mermaid rendering and PDF export.
+- If people compare it to Glow, say it is Glow-like but Mermaid-focused.


### PR DESCRIPTION
## Summary

Prepare glowm for a global OSS launch and GitHub star conversion.

- Reposition README around terminal-first architecture docs and inline Mermaid rendering
- Add comparison table, quick start, install paths, requirements, and launch docs
- Add MIT license and OSS trust files: contributing guide, security policy, code of conduct, issue templates, PR template, discussion template
- Add launch kit and global launch checklist with recommended GitHub metadata/topics

## Testing

- `git diff --check` passed
- `go test ./...` could not run locally because this environment has Go 1.22.2 and the repo requires Go 1.26; GitHub Actions is configured with Go 1.26 and should be used as the verification gate.
