### PR TITLE
test: raise coverage to >=80% and add Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,13 @@ jobs:
         env:
           GLOWM_CHROME_NO_SANDBOX: "1"
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+        with:
+          files: ./coverage.out
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Check coverage
         run: |
           COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | tr -d '%')

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # local
 /.serena
 
+# coverage
+/coverage.out
+
 /docs/*
 !/docs/README-demo.png
 !/docs/*.md

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # glowm
 
+[![codecov](https://codecov.io/gh/atani/glowm/branch/main/graph/badge.svg)](https://codecov.io/gh/atani/glowm)
+
 **Read Markdown architecture docs in your terminal — with Mermaid diagrams rendered inline.**
 
 `glowm` is a terminal-first Markdown viewer for developers who keep design docs, ADRs, and diagrams next to the code. It renders Markdown beautifully in the terminal, displays Mermaid diagrams inline on modern terminals like iTerm2, Kitty, and Ghostty, and can export diagrams to PDF when you need to share them outside the terminal.

--- a/cmd/glowm/main.go
+++ b/cmd/glowm/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -24,43 +25,64 @@ var (
 	date    = "unknown"
 )
 
+// options holds parsed command-line flags.
+type options struct {
+	width       int
+	style       string
+	usePager    bool
+	noPager     bool
+	pdf         bool
+	showVersion bool
+	positional  []string
+}
+
+// parseFlags parses argv (excluding the program name) into options.
+func parseFlags(args []string) (options, error) {
+	fs := flag.NewFlagSet("glowm", flag.ContinueOnError)
+	var opts options
+	fs.IntVar(&opts.width, "w", 0, "word wrap width")
+	fs.StringVar(&opts.style, "s", "auto", "style name or JSON path")
+	fs.BoolVar(&opts.usePager, "p", false, "force pager output")
+	fs.BoolVar(&opts.noPager, "no-pager", false, "disable pager")
+	fs.BoolVar(&opts.pdf, "pdf", false, "output mermaid diagrams as PDF to stdout")
+	fs.BoolVar(&opts.showVersion, "version", false, "show version information")
+	if err := fs.Parse(args); err != nil {
+		return options{}, err
+	}
+	opts.positional = fs.Args()
+	return opts, nil
+}
+
 func main() {
-	var (
-		width       = flag.Int("w", 0, "word wrap width")
-		style       = flag.String("s", "auto", "style name or JSON path")
-		usePager    = flag.Bool("p", false, "force pager output")
-		noPager     = flag.Bool("no-pager", false, "disable pager")
-		pdf         = flag.Bool("pdf", false, "output mermaid diagrams as PDF to stdout")
-		showVersion = flag.Bool("version", false, "show version information")
-	)
-	flag.Parse()
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
 
-	if *showVersion {
-		fmt.Printf("glowm %s (commit: %s, built: %s)\n", version, commit, date)
-		return
-	}
-
-	md, err := input.Read(flag.Args())
+// run executes the program with the given args, writing primary output to
+// stdout and diagnostics to stderr. It returns the process exit code.
+//
+// TTY-dependent rendering (terminal images, interactive pager) reads global
+// terminal state and is only engaged when stdout is a real terminal; in the
+// common non-TTY path the rendered markdown is written directly to stdout,
+// which makes run fully testable with in-memory writers.
+func run(args []string, stdout, stderr io.Writer) int {
+	opts, err := parseFlags(args)
 	if err != nil {
-		exitWithError(err)
+		// flag already reported the error to its own output.
+		return 2
 	}
 
-	if *pdf {
-		result, err := markdown.ExtractMermaid(md, false)
-		if err != nil {
-			exitWithError(err)
-		}
-		if len(result.Blocks) == 0 {
-			exitWithError(errors.New("no mermaid blocks found"))
-		}
-		pdfBytes, err := mermaid.RenderPDF(result.Blocks)
-		if err != nil {
-			exitWithError(err)
-		}
-		if _, err := os.Stdout.Write(pdfBytes); err != nil {
-			exitWithError(err)
-		}
-		return
+	if opts.showVersion {
+		fmt.Fprintf(stdout, "glowm %s (commit: %s, built: %s)\n", version, commit, date)
+		return 0
+	}
+
+	md, err := input.Read(opts.positional)
+	if err != nil {
+		return fail(stderr, err)
+	}
+
+	if opts.pdf {
+		return runPDF(md, stdout, stderr)
 	}
 
 	stdoutTTY := terminal.StdoutIsTTY()
@@ -69,86 +91,112 @@ func main() {
 	cfg := config.Load()
 	pagerMode := pager.Mode(strings.ToLower(cfg.Pager.Mode))
 	if !pager.ValidMode(pagerMode) {
-		fmt.Fprintf(os.Stderr, "glowm: unknown pager mode %q, using more\n", cfg.Pager.Mode)
+		fmt.Fprintf(stderr, "glowm: unknown pager mode %q, using more\n", cfg.Pager.Mode)
 		pagerMode = pager.ModeMore
 	}
-	isPagerEnabledByDefault := stdoutTTY && !*noPager
-	shouldUsePager := *usePager || isPagerEnabledByDefault
+	shouldUsePager := opts.usePager || (stdoutTTY && !opts.noPager)
 
 	if stdoutTTY && imageFormat != termimage.FormatNone {
-		result, err := markdown.ExtractMermaidWithMarkers(md)
-		if err != nil {
-			exitWithError(err)
-		}
-		if len(result.Blocks) > 0 {
-			w := *width
-			if w == 0 {
-				w = terminal.StdoutWidth(80)
-			}
-			images, renderErr := mermaid.RenderPNGs(result.Blocks, w)
-			if renderErr == nil {
-				output, err := render.ANSI(result.Markdown, render.RenderOptions{
-					Width: w,
-					Style: *style,
-					TTY:   stdoutTTY,
-				})
-				if err != nil {
-					exitWithError(err)
-				}
-				output = termimage.ReplaceMarkersWithImages(output, result.Markers, images, imageFormat, w)
-
-				if shouldUsePager {
-					if err := pager.PageWithMode(output, pagerMode); err != nil {
-						exitWithError(err)
-					}
-					return
-				}
-				if _, err := fmt.Fprint(os.Stdout, output); err != nil {
-					exitWithError(err)
-				}
-				return
-			}
-			// Mermaid rendering failed — fall through to text-only output.
-			fmt.Fprintf(os.Stderr, "warning: mermaid rendering failed: %v\n", renderErr)
+		handled, code := runWithImages(md, opts, stdoutTTY, imageFormat, pagerMode, shouldUsePager, stdout, stderr)
+		if handled {
+			return code
 		}
 	}
 
-	keepBlocks := stdoutTTY
-	result, err := markdown.ExtractMermaid(md, keepBlocks)
+	result, err := markdown.ExtractMermaid(md, stdoutTTY)
 	if err != nil {
-		exitWithError(err)
+		return fail(stderr, err)
 	}
 
-	w := *width
+	w := opts.width
 	if w == 0 {
 		w = terminal.StdoutWidth(80)
 	}
 
 	output, err := render.ANSI(result.Markdown, render.RenderOptions{
 		Width: w,
-		Style: *style,
+		Style: opts.style,
 		TTY:   stdoutTTY,
 	})
 	if err != nil {
-		exitWithError(err)
+		return fail(stderr, err)
 	}
 
 	if shouldUsePager && stdoutTTY {
 		if err := pager.PageWithMode(output, pagerMode); err != nil {
-			exitWithError(err)
+			return fail(stderr, err)
 		}
-		return
+		return 0
 	}
 
-	if _, err := fmt.Fprint(os.Stdout, output); err != nil {
-		exitWithError(err)
+	if _, err := fmt.Fprint(stdout, output); err != nil {
+		return fail(stderr, err)
 	}
+	return 0
 }
 
-func exitWithError(err error) {
-	if err == nil {
-		os.Exit(0)
+// runPDF renders mermaid blocks to PDF bytes written to stdout.
+func runPDF(md string, stdout, stderr io.Writer) int {
+	result, err := markdown.ExtractMermaid(md, false)
+	if err != nil {
+		return fail(stderr, err)
 	}
-	fmt.Fprintln(os.Stderr, render.FormatError(err))
-	os.Exit(1)
+	if len(result.Blocks) == 0 {
+		return fail(stderr, errors.New("no mermaid blocks found"))
+	}
+	pdfBytes, err := mermaid.RenderPDF(result.Blocks)
+	if err != nil {
+		return fail(stderr, err)
+	}
+	if _, err := stdout.Write(pdfBytes); err != nil {
+		return fail(stderr, err)
+	}
+	return 0
+}
+
+// runWithImages renders markdown with inline terminal images. It returns
+// handled=false when there are no mermaid blocks or rendering fails, so the
+// caller can fall back to the text-only path.
+func runWithImages(md string, opts options, stdoutTTY bool, imageFormat termimage.Format, pagerMode pager.Mode, shouldUsePager bool, stdout, stderr io.Writer) (handled bool, code int) {
+	result, err := markdown.ExtractMermaidWithMarkers(md)
+	if err != nil {
+		return true, fail(stderr, err)
+	}
+	if len(result.Blocks) == 0 {
+		return false, 0
+	}
+	w := opts.width
+	if w == 0 {
+		w = terminal.StdoutWidth(80)
+	}
+	images, renderErr := mermaid.RenderPNGs(result.Blocks, w)
+	if renderErr != nil {
+		fmt.Fprintf(stderr, "warning: mermaid rendering failed: %v\n", renderErr)
+		return false, 0
+	}
+	output, err := render.ANSI(result.Markdown, render.RenderOptions{
+		Width: w,
+		Style: opts.style,
+		TTY:   stdoutTTY,
+	})
+	if err != nil {
+		return true, fail(stderr, err)
+	}
+	output = termimage.ReplaceMarkersWithImages(output, result.Markers, images, imageFormat, w)
+	if shouldUsePager {
+		if err := pager.PageWithMode(output, pagerMode); err != nil {
+			return true, fail(stderr, err)
+		}
+		return true, 0
+	}
+	if _, err := fmt.Fprint(stdout, output); err != nil {
+		return true, fail(stderr, err)
+	}
+	return true, 0
+}
+
+// fail writes a formatted error to stderr and returns exit code 1.
+func fail(stderr io.Writer, err error) int {
+	fmt.Fprintln(stderr, render.FormatError(err))
+	return 1
 }

--- a/cmd/glowm/main_test.go
+++ b/cmd/glowm/main_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func chromeAvailable() bool {
+	candidates := []string{
+		"google-chrome",
+		"google-chrome-stable",
+		"chromium",
+		"chromium-browser",
+		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+		"/Applications/Chromium.app/Contents/MacOS/Chromium",
+	}
+	for _, c := range candidates {
+		if _, err := exec.LookPath(c); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func TestParseFlags_Defaults(t *testing.T) {
+	opts, err := parseFlags(nil)
+	if err != nil {
+		t.Fatalf("parseFlags(nil) error: %v", err)
+	}
+	if opts.width != 0 || opts.style != "auto" || opts.usePager || opts.noPager || opts.pdf || opts.showVersion {
+		t.Errorf("unexpected defaults: %+v", opts)
+	}
+}
+
+func TestParseFlags_AllSet(t *testing.T) {
+	opts, err := parseFlags([]string{"-w", "100", "-s", "dark", "-p", "-no-pager", "file.md"})
+	if err != nil {
+		t.Fatalf("parseFlags error: %v", err)
+	}
+	if opts.width != 100 {
+		t.Errorf("width = %d, want 100", opts.width)
+	}
+	if opts.style != "dark" {
+		t.Errorf("style = %q, want dark", opts.style)
+	}
+	if !opts.usePager || !opts.noPager {
+		t.Errorf("pager flags not set: %+v", opts)
+	}
+	if len(opts.positional) != 1 || opts.positional[0] != "file.md" {
+		t.Errorf("positional = %v, want [file.md]", opts.positional)
+	}
+}
+
+func TestParseFlags_Invalid(t *testing.T) {
+	_, err := parseFlags([]string{"-nonexistent-flag"})
+	if err == nil {
+		t.Fatal("expected error for unknown flag")
+	}
+}
+
+func TestRun_Version(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := run([]string{"-version"}, &out, &errBuf)
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "glowm") {
+		t.Errorf("version output missing 'glowm': %q", out.String())
+	}
+}
+
+func TestRun_InvalidFlag(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := run([]string{"-bogus"}, &out, &errBuf)
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2 for invalid flag", code)
+	}
+}
+
+func TestRun_RendersFileToStdout(t *testing.T) {
+	// Non-TTY path: a markdown file is rendered and written to the provided
+	// stdout writer. Under `go test` stdout is not a terminal, so this
+	// exercises the common text-only branch end to end.
+	dir := t.TempDir()
+	mdPath := filepath.Join(dir, "doc.md")
+	if err := os.WriteFile(mdPath, []byte("# Heading\n\nbody paragraph\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errBuf bytes.Buffer
+	code := run([]string{"-s", "notty", mdPath}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errBuf.String())
+	}
+	if !strings.Contains(out.String(), "Heading") {
+		t.Errorf("output missing heading: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "body paragraph") {
+		t.Errorf("output missing body: %q", out.String())
+	}
+}
+
+func TestRun_MissingFile(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := run([]string{filepath.Join(t.TempDir(), "does-not-exist.md")}, &out, &errBuf)
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1 for missing file", code)
+	}
+	if errBuf.Len() == 0 {
+		t.Error("expected an error message on stderr")
+	}
+}
+
+func TestRun_NoInput(t *testing.T) {
+	// No positional args and stdin is not a pipe (interactive test env) ->
+	// input.Read returns ErrNoInput -> exit 1. Skip when stdin happens to be
+	// a pipe (e.g. CI feeding stdin) to avoid blocking on a read.
+	stat, err := os.Stdin.Stat()
+	if err == nil && (stat.Mode()&os.ModeCharDevice) == 0 {
+		t.Skip("stdin is a pipe in this environment; skipping no-input case")
+	}
+	var out, errBuf bytes.Buffer
+	code := run(nil, &out, &errBuf)
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1 when no input", code)
+	}
+}
+
+func TestFail(t *testing.T) {
+	var errBuf bytes.Buffer
+	code := fail(&errBuf, errors.New("boom"))
+	if code != 1 {
+		t.Errorf("fail() code = %d, want 1", code)
+	}
+	if !strings.Contains(errBuf.String(), "boom") {
+		t.Errorf("fail() stderr = %q, want to contain 'boom'", errBuf.String())
+	}
+}
+
+func TestRunPDF_Success(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("chrome dependency not supported on this platform")
+	}
+	if !chromeAvailable() {
+		t.Skip("chrome/chromium not available")
+	}
+	md := "```mermaid\nflowchart TD\n  A-->B\n```\n"
+	var out, errBuf bytes.Buffer
+	code := runPDF(md, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("runPDF code = %d, want 0 (stderr: %s)", code, errBuf.String())
+	}
+	if out.Len() < 4 || out.String()[:4] != "%PDF" {
+		t.Errorf("expected PDF output, got %q", out.String()[:min(8, out.Len())])
+	}
+}
+
+func TestRun_PDFFlagNoBlocks(t *testing.T) {
+	// The -pdf flag with no mermaid blocks exits 1 via the runPDF path.
+	dir := t.TempDir()
+	mdPath := filepath.Join(dir, "plain.md")
+	if err := os.WriteFile(mdPath, []byte("# just text\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errBuf bytes.Buffer
+	code := run([]string{"-pdf", mdPath}, &out, &errBuf)
+	if code != 1 {
+		t.Errorf("code = %d, want 1", code)
+	}
+	if !strings.Contains(errBuf.String(), "no mermaid blocks") {
+		t.Errorf("stderr = %q", errBuf.String())
+	}
+}
+
+func TestRunPDF_NoMermaidBlocks(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runPDF("# Just text, no diagrams\n", &out, &errBuf)
+	if code != 1 {
+		t.Errorf("code = %d, want 1 when no mermaid blocks", code)
+	}
+	if !strings.Contains(errBuf.String(), "no mermaid blocks") {
+		t.Errorf("stderr = %q, want 'no mermaid blocks'", errBuf.String())
+	}
+}

--- a/cmd/glowm/main_test.go
+++ b/cmd/glowm/main_test.go
@@ -4,29 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 )
-
-func chromeAvailable() bool {
-	candidates := []string{
-		"google-chrome",
-		"google-chrome-stable",
-		"chromium",
-		"chromium-browser",
-		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-		"/Applications/Chromium.app/Contents/MacOS/Chromium",
-	}
-	for _, c := range candidates {
-		if _, err := exec.LookPath(c); err == nil {
-			return true
-		}
-	}
-	return false
-}
 
 func TestParseFlags_Defaults(t *testing.T) {
 	opts, err := parseFlags(nil)
@@ -139,24 +120,6 @@ func TestFail(t *testing.T) {
 	}
 	if !strings.Contains(errBuf.String(), "boom") {
 		t.Errorf("fail() stderr = %q, want to contain 'boom'", errBuf.String())
-	}
-}
-
-func TestRunPDF_Success(t *testing.T) {
-	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
-		t.Skip("chrome dependency not supported on this platform")
-	}
-	if !chromeAvailable() {
-		t.Skip("chrome/chromium not available")
-	}
-	md := "```mermaid\nflowchart TD\n  A-->B\n```\n"
-	var out, errBuf bytes.Buffer
-	code := runPDF(md, &out, &errBuf)
-	if code != 0 {
-		t.Fatalf("runPDF code = %d, want 0 (stderr: %s)", code, errBuf.String())
-	}
-	if out.Len() < 4 || out.String()[:4] != "%PDF" {
-		t.Errorf("expected PDF output, got %q", out.String()[:min(8, out.Len())])
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -79,6 +80,18 @@ func TestLoad_EmptyConfig(t *testing.T) {
 	cfg := Load()
 	if cfg.Pager.Mode != "more" {
 		t.Errorf("mode = %q, want %q", cfg.Pager.Mode, "more")
+	}
+}
+
+func TestConfigPath(t *testing.T) {
+	// configPath builds on os.UserConfigDir(). Regardless of platform the
+	// result must point at glowm/config.json under the user config dir.
+	got, err := configPath()
+	if err != nil {
+		t.Fatalf("configPath() error: %v", err)
+	}
+	if !strings.HasSuffix(filepath.ToSlash(got), "glowm/config.json") {
+		t.Errorf("configPath() = %q, want suffix glowm/config.json", got)
 	}
 }
 

--- a/internal/input/input_test.go
+++ b/internal/input/input_test.go
@@ -72,6 +72,58 @@ func TestRead_StdinDash(t *testing.T) {
 	}
 }
 
+func TestRead_NoArgsWithPipedStdin(t *testing.T) {
+	// Empty args with data available on stdin (a pipe) must read it, covering
+	// the stdinHasData()==true branch and the readStdin path via Read(nil).
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	go func() {
+		w.WriteString("# from pipe\n")
+		w.Close()
+	}()
+
+	got, err := Read(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "# from pipe\n" {
+		t.Fatalf("got %q, want '# from pipe\\n'", got)
+	}
+}
+
+func TestRead_StdinTooLarge(t *testing.T) {
+	// Piping more than maxInputSize bytes via "-" must be rejected.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	go func() {
+		chunk := make([]byte, 1<<20) // 1 MiB
+		for range 11 {               // 11 MiB > 10 MiB limit
+			w.Write(chunk)
+		}
+		w.Close()
+	}()
+
+	_, err = Read([]string{"-"})
+	if err == nil {
+		t.Fatal("expected error for oversized stdin")
+	}
+	if !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRead_FileTooLarge(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "big.md")

--- a/internal/markdown/mermaid_test.go
+++ b/internal/markdown/mermaid_test.go
@@ -197,3 +197,55 @@ func TestExtractMermaidIndentedFenceClosing(t *testing.T) {
 		t.Fatalf("expected 1 block, got %d", len(res.Blocks))
 	}
 }
+
+func TestFenceStart(t *testing.T) {
+	tests := []struct {
+		name      string
+		line      string
+		wantFence string
+		wantOK    bool
+	}{
+		{"backtick fence", "```", "```", true},
+		{"backtick fence with info", "```mermaid", "```", true},
+		{"longer backtick fence", "````", "````", true},
+		{"tilde fence", "~~~", "~~~", true},
+		{"tilde fence with info", "~~~go", "~~~", true},
+		{"too short", "``", "", false},
+		{"not a fence", "plain text", "", false},
+		{"empty", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFence, gotOK := fenceStart(tt.line)
+			if gotFence != tt.wantFence || gotOK != tt.wantOK {
+				t.Errorf("fenceStart(%q) = (%q,%v), want (%q,%v)",
+					tt.line, gotFence, gotOK, tt.wantFence, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestIsFenceEnd(t *testing.T) {
+	tests := []struct {
+		name  string
+		line  string
+		fence string
+		want  bool
+	}{
+		{"exact match", "```", "```", true},
+		{"longer closing allowed", "````", "```", true},
+		{"shorter closing rejected", "``", "```", false},
+		{"trailing spaces allowed", "```   ", "```", true},
+		{"leading indent allowed", "  ```", "```", true},
+		{"different char rejected", "~~~", "```", false},
+		{"mixed chars rejected", "``~", "```", false},
+		{"tilde fence closes tilde", "~~~", "~~~", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isFenceEnd(tt.line, tt.fence); got != tt.want {
+				t.Errorf("isFenceEnd(%q,%q) = %v, want %v", tt.line, tt.fence, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/pager/ansi_test.go
+++ b/internal/pager/ansi_test.go
@@ -103,6 +103,11 @@ func TestHighlightLine(t *testing.T) {
 		{"plain text match", "hello world", "hello world", "world", "hello \033[7mworld\033[0m"},
 		{"match with ANSI", "\033[31mhello\033[0m", "hello", "hello", "\033[31m\033[7mhello\033[0m\033[0m"},
 		{"multiple matches", "abc abc", "abc abc", "abc", "\033[7mabc\033[0m \033[7mabc\033[0m"},
+		// When plain length disagrees with the visible map derived from
+		// original, highlighting is skipped and original is returned as-is.
+		{"index map mismatch returns original", "ab", "abc", "a", "ab"},
+		// Adjacent (non-overlapping) matches both get highlighted.
+		{"adjacent matches", "aa", "aa", "a", "\033[7ma\033[0m\033[7ma\033[0m"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -215,6 +220,9 @@ func TestSkipEscapeSequence(t *testing.T) {
 		{"OSC with BEL", "\033]0;title\007", 0, 9},
 		{"lone ESC at end", "\033", 0, 0},
 		{"ESC with unknown", "\033X", 0, 1},
+		{"unterminated CSI", "\033[31", 0, 3},
+		{"unterminated OSC", "\033]0;title", 0, 8},
+		{"OSC with ST terminator", "\033]8;;x\033\\", 0, 7},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/pager/input_test.go
+++ b/internal/pager/input_test.go
@@ -1,0 +1,317 @@
+package pager
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// newReader wraps a byte string in a *bufio.Reader for feeding to the
+// key/search parsing functions.
+func newReader(s string) *bufio.Reader {
+	return bufio.NewReader(strings.NewReader(s))
+}
+
+func TestReadKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantTyp keyType
+	}{
+		{"quit q", "q", keyQuit},
+		{"quit Q", "Q", keyQuit},
+		{"space page down", " ", keyPageDown},
+		{"b page up", "b", keyPageUp},
+		{"ctrl-f page down", "\x06", keyPageDown},
+		{"ctrl-b page up", "\x02", keyPageUp},
+		{"j down", "j", keyDown},
+		{"newline down", "\n", keyDown},
+		{"k up", "k", keyUp},
+		{"g", "g", keyG},
+		{"G bottom", "G", keyBottom},
+		{"n search next", "n", keySearchNext},
+		{"N search prev", "N", keySearchPrev},
+		{"* search word", "*", keySearchWord},
+		{"# search word backward", "#", keySearchWordBackward},
+		{"unknown char", "x", keyUnknown},
+		{"EOF returns quit", "", keyQuit},
+		{"arrow up", "\x1b[A", keyUp},
+		{"arrow down", "\x1b[B", keyDown},
+		{"page up esc 5", "\x1b[5~", keyPageUp},
+		{"page down esc 6", "\x1b[6~", keyPageDown},
+		{"esc without bracket", "\x1bX", keyUnknown},
+		{"esc unknown code", "\x1b[Z", keyUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newReader(tt.input)
+			var w bytes.Buffer
+			bw := bufio.NewWriter(&w)
+			p := newTestState([]string{"a", "b"}, 10)
+			got := readKey(r, bw, p)
+			if got.typ != tt.wantTyp {
+				t.Errorf("readKey(%q).typ = %d, want %d", tt.input, got.typ, tt.wantTyp)
+			}
+		})
+	}
+}
+
+func TestReadKey_SearchForward(t *testing.T) {
+	r := newReader("/foo\n")
+	var w bytes.Buffer
+	bw := bufio.NewWriter(&w)
+	p := newTestState([]string{"foo", "bar"}, 10)
+	got := readKey(r, bw, p)
+	if got.typ != keySearch {
+		t.Fatalf("typ = %d, want keySearch", got.typ)
+	}
+	if got.text != "foo" {
+		t.Errorf("text = %q, want 'foo'", got.text)
+	}
+	if len(p.history) != 1 || p.history[0] != "foo" {
+		t.Errorf("history = %v, want [foo]", p.history)
+	}
+}
+
+func TestReadKey_SearchBackward(t *testing.T) {
+	r := newReader("?bar\r")
+	var w bytes.Buffer
+	bw := bufio.NewWriter(&w)
+	p := newTestState([]string{"foo", "bar"}, 10)
+	got := readKey(r, bw, p)
+	if got.typ != keySearchBackward {
+		t.Fatalf("typ = %d, want keySearchBackward", got.typ)
+	}
+	if got.text != "bar" {
+		t.Errorf("text = %q, want 'bar'", got.text)
+	}
+}
+
+func TestReadKey_EmptySearchIsUnknown(t *testing.T) {
+	// Pressing '/' then immediately Enter yields an empty search and must
+	// not be dispatched as a search.
+	r := newReader("/\n")
+	var w bytes.Buffer
+	bw := bufio.NewWriter(&w)
+	p := newTestState([]string{"a"}, 10)
+	got := readKey(r, bw, p)
+	if got.typ != keyUnknown {
+		t.Errorf("empty search typ = %d, want keyUnknown", got.typ)
+	}
+	if len(p.history) != 0 {
+		t.Errorf("empty search should not be added to history, got %v", p.history)
+	}
+}
+
+func TestReadSearch(t *testing.T) {
+	t.Run("plain text terminated by enter", func(t *testing.T) {
+		r := newReader("hello\n")
+		var w bytes.Buffer
+		bw := bufio.NewWriter(&w)
+		p := newTestState([]string{"a"}, 10)
+		got := readSearch(r, bw, p, "/")
+		if got != "hello" {
+			t.Errorf("got %q, want 'hello'", got)
+		}
+		if p.status != "" {
+			t.Errorf("status = %q, want empty after enter", p.status)
+		}
+	})
+
+	t.Run("backspace deletes last char", func(t *testing.T) {
+		r := newReader("abc\x7f\n") // type abc, delete c -> "ab"
+		var w bytes.Buffer
+		bw := bufio.NewWriter(&w)
+		p := newTestState([]string{"a"}, 10)
+		got := readSearch(r, bw, p, "/")
+		if got != "ab" {
+			t.Errorf("got %q, want 'ab'", got)
+		}
+	})
+
+	t.Run("backspace on empty buffer is a no-op", func(t *testing.T) {
+		r := newReader("\x7f\n")
+		var w bytes.Buffer
+		bw := bufio.NewWriter(&w)
+		p := newTestState([]string{"a"}, 10)
+		got := readSearch(r, bw, p, "/")
+		if got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("escape cancels search", func(t *testing.T) {
+		r := newReader("ab\x1bX") // escape not followed by '[' cancels
+		var w bytes.Buffer
+		bw := bufio.NewWriter(&w)
+		p := newTestState([]string{"a"}, 10)
+		got := readSearch(r, bw, p, "/")
+		if got != "" {
+			t.Errorf("got %q, want empty (cancelled)", got)
+		}
+	})
+
+	t.Run("control chars below 0x20 ignored", func(t *testing.T) {
+		r := newReader("a\x01b\n") // \x01 (ctrl-a) must be ignored
+		var w bytes.Buffer
+		bw := bufio.NewWriter(&w)
+		p := newTestState([]string{"a"}, 10)
+		got := readSearch(r, bw, p, "/")
+		if got != "ab" {
+			t.Errorf("got %q, want 'ab'", got)
+		}
+	})
+
+	t.Run("EOF returns empty", func(t *testing.T) {
+		r := newReader("ab")
+		var w bytes.Buffer
+		bw := bufio.NewWriter(&w)
+		p := newTestState([]string{"a"}, 10)
+		got := readSearch(r, bw, p, "/")
+		if got != "" {
+			t.Errorf("got %q, want empty on EOF", got)
+		}
+	})
+
+	t.Run("up arrow recalls history", func(t *testing.T) {
+		r := newReader("\x1b[A\n") // up arrow then enter
+		var w bytes.Buffer
+		bw := bufio.NewWriter(&w)
+		p := newTestState([]string{"a"}, 10)
+		p.history = []string{"prev"}
+		got := readSearch(r, bw, p, "/")
+		if got != "prev" {
+			t.Errorf("got %q, want 'prev' from history", got)
+		}
+	})
+
+	t.Run("down arrow navigates history forward", func(t *testing.T) {
+		r := newReader("\x1b[A\x1b[A\x1b[B\n") // up up down
+		var w bytes.Buffer
+		bw := bufio.NewWriter(&w)
+		p := newTestState([]string{"a"}, 10)
+		p.history = []string{"first", "second"}
+		got := readSearch(r, bw, p, "/")
+		// up,up -> "first", down -> "second"
+		if got != "second" {
+			t.Errorf("got %q, want 'second'", got)
+		}
+	})
+}
+
+func TestHandleSearchEscape(t *testing.T) {
+	t.Run("non-bracket sequence cancels", func(t *testing.T) {
+		r := newReader("X")
+		var w bytes.Buffer
+		bw := bufio.NewWriter(&w)
+		p := newTestState([]string{"a"}, 10)
+		handled, _ := handleSearchEscape(r, bw, p, "/", []byte("ab"), 80)
+		if handled {
+			t.Error("expected non-bracket escape to be unhandled (cancel)")
+		}
+	})
+
+	t.Run("unknown code cancels", func(t *testing.T) {
+		r := newReader("[Z")
+		var w bytes.Buffer
+		bw := bufio.NewWriter(&w)
+		p := newTestState([]string{"a"}, 10)
+		handled, _ := handleSearchEscape(r, bw, p, "/", nil, 80)
+		if handled {
+			t.Error("expected unknown code to be unhandled")
+		}
+	})
+}
+
+func TestSearchWord(t *testing.T) {
+	lines := []string{"apple", "banana", "apple pie", "cherry"}
+
+	t.Run("finds next occurrence of word under cursor", func(t *testing.T) {
+		p := newTestState(lines, 10)
+		p.cursor = 0 // word "apple"
+		p.searchWord(dirForward)
+		if p.lastSearch != "apple" {
+			t.Errorf("lastSearch = %q, want 'apple'", p.lastSearch)
+		}
+		if p.cursor != 2 {
+			t.Errorf("cursor = %d, want 2", p.cursor)
+		}
+	})
+
+	t.Run("no word under cursor sets status", func(t *testing.T) {
+		p := newTestState([]string{"---", "banana"}, 10)
+		p.cursor = 0
+		p.searchWord(dirForward)
+		if p.status != "no word under cursor" {
+			t.Errorf("status = %q, want 'no word under cursor'", p.status)
+		}
+	})
+
+	t.Run("backward direction recorded", func(t *testing.T) {
+		p := newTestState(lines, 10)
+		p.cursor = 2 // "apple pie" -> apple
+		p.searchWord(dirBackward)
+		if p.lastDir != dirBackward {
+			t.Error("expected lastDir to be dirBackward")
+		}
+		if p.cursor != 0 {
+			t.Errorf("cursor = %d, want 0", p.cursor)
+		}
+	})
+}
+
+func TestHandleKey_SearchNavigation(t *testing.T) {
+	lines := []string{"apple", "banana", "apple pie", "cherry"}
+
+	t.Run("keySearchNext repeats last search", func(t *testing.T) {
+		p := newTestState(lines, 10)
+		p.lastSearch = "apple"
+		p.lastDir = dirForward
+		p.cursor = 0
+		p.handleKey(key{typ: keySearchNext})
+		if p.cursor != 2 {
+			t.Errorf("cursor = %d, want 2", p.cursor)
+		}
+	})
+
+	t.Run("keySearchPrev reverses direction", func(t *testing.T) {
+		p := newTestState(lines, 10)
+		p.lastSearch = "apple"
+		p.lastDir = dirForward
+		p.cursor = 2
+		p.handleKey(key{typ: keySearchPrev})
+		if p.cursor != 0 {
+			t.Errorf("cursor = %d, want 0", p.cursor)
+		}
+	})
+
+	t.Run("keySearchWord searches word under cursor", func(t *testing.T) {
+		p := newTestState(lines, 10)
+		p.cursor = 0
+		p.handleKey(key{typ: keySearchWord})
+		if p.cursor != 2 || p.lastSearch != "apple" {
+			t.Errorf("cursor=%d lastSearch=%q, want 2/'apple'", p.cursor, p.lastSearch)
+		}
+	})
+
+	t.Run("keySearchWordBackward searches word backward", func(t *testing.T) {
+		p := newTestState(lines, 10)
+		p.cursor = 2
+		p.handleKey(key{typ: keySearchWordBackward})
+		if p.cursor != 0 {
+			t.Errorf("cursor = %d, want 0", p.cursor)
+		}
+	})
+
+	t.Run("unknown key is a no-op", func(t *testing.T) {
+		p := newTestState(lines, 10)
+		p.cursor = 1
+		if p.handleKey(key{typ: keyUnknown}) {
+			t.Error("keyUnknown should not signal exit")
+		}
+		if p.cursor != 1 {
+			t.Errorf("cursor moved to %d on unknown key", p.cursor)
+		}
+	})
+}

--- a/internal/pager/render_test.go
+++ b/internal/pager/render_test.go
@@ -1,0 +1,110 @@
+package pager
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestDrawStatus(t *testing.T) {
+	t.Run("default status shows position and total", func(t *testing.T) {
+		p := newTestState([]string{"a", "b", "c"}, 10)
+		p.top = 0
+		var buf bytes.Buffer
+		w := bufio.NewWriter(&buf)
+		p.drawStatus(w, 200)
+		w.Flush()
+		out := buf.String()
+		if !strings.Contains(out, "1/3") {
+			t.Errorf("status output missing position 1/3: %q", out)
+		}
+		if !strings.Contains(out, "glowm pager") {
+			t.Errorf("status output missing label: %q", out)
+		}
+	})
+
+	t.Run("empty document reports line 0", func(t *testing.T) {
+		p := newTestState(nil, 10)
+		var buf bytes.Buffer
+		w := bufio.NewWriter(&buf)
+		p.drawStatus(w, 200)
+		w.Flush()
+		if !strings.Contains(buf.String(), "0/0") {
+			t.Errorf("empty doc status missing 0/0: %q", buf.String())
+		}
+	})
+
+	t.Run("custom status overrides default", func(t *testing.T) {
+		p := newTestState([]string{"a"}, 10)
+		p.status = "pattern not found"
+		var buf bytes.Buffer
+		w := bufio.NewWriter(&buf)
+		p.drawStatus(w, 200)
+		w.Flush()
+		out := buf.String()
+		if !strings.Contains(out, "pattern not found") {
+			t.Errorf("custom status not shown: %q", out)
+		}
+		if strings.Contains(out, "glowm pager") {
+			t.Errorf("default status leaked when custom set: %q", out)
+		}
+	})
+}
+
+func TestRedraw(t *testing.T) {
+	t.Run("renders visible window with reverse-video cursor", func(t *testing.T) {
+		p := newTestState([]string{"line0", "line1", "line2"}, 10)
+		p.cursor = 1
+		var buf bytes.Buffer
+		w := bufio.NewWriter(&buf)
+		p.redraw(w)
+		w.Flush()
+		out := buf.String()
+		for _, l := range []string{"line0", "line1", "line2"} {
+			if !strings.Contains(out, l) {
+				t.Errorf("redraw output missing %q: %q", l, out)
+			}
+		}
+		// Cursor line is highlighted with reverse video.
+		if !strings.Contains(out, ansiReverseVideo) {
+			t.Errorf("redraw missing reverse-video for cursor line")
+		}
+		if !strings.HasPrefix(out, ansiClearScreen) {
+			t.Errorf("redraw should clear screen first")
+		}
+	})
+
+	t.Run("highlights search matches", func(t *testing.T) {
+		p := newTestState([]string{"hello world", "no match here"}, 10)
+		p.lastSearch = "world"
+		var buf bytes.Buffer
+		w := bufio.NewWriter(&buf)
+		p.redraw(w)
+		w.Flush()
+		// A highlighted match wraps the term in reverse video then reset.
+		if !strings.Contains(buf.String(), ansiReverseVideo+"world"+ansiReset) {
+			t.Errorf("search match not highlighted: %q", buf.String())
+		}
+	})
+
+	t.Run("pads short documents to fill the page", func(t *testing.T) {
+		p := newTestState([]string{"only line"}, 5) // linesPerPage = 4
+		var buf bytes.Buffer
+		w := bufio.NewWriter(&buf)
+		p.redraw(w)
+		w.Flush()
+		// One content line + padding "\r\n" rows should fill remaining space.
+		if strings.Count(buf.String(), "\r\n") < 4 {
+			t.Errorf("expected page padding to fill window, got %q", buf.String())
+		}
+	})
+}
+
+func TestPrintOutput(t *testing.T) {
+	// printOutput writes to os.Stdout; just verify it returns no error for
+	// normal content (the write target is the process stdout).
+	if err := printOutput(""); err != nil {
+		t.Errorf("printOutput(empty) error: %v", err)
+	}
+}

--- a/internal/pager/signal_test.go
+++ b/internal/pager/signal_test.go
@@ -1,0 +1,46 @@
+package pager
+
+import (
+	"testing"
+
+	"golang.org/x/term"
+)
+
+// TestSetupSignalHandler verifies the handler installs and the returned
+// cleanup function stops the handler goroutine without firing a signal.
+// The signal-receive branch is not exercised because it calls os.Exit.
+func TestSetupSignalHandler_InstallAndCleanup(t *testing.T) {
+	var restored bool
+	cleanup := setupSignalHandler(-1, &term.State{}, func() { restored = true })
+	if cleanup == nil {
+		t.Fatal("expected a non-nil cleanup function")
+	}
+	// Calling cleanup must stop the goroutine and return promptly.
+	cleanup()
+	// extraCleanup is only invoked on signal receipt, so it must not have run.
+	if restored {
+		t.Error("extraCleanup should not run during normal cleanup")
+	}
+}
+
+func TestSetupSignalHandler_NilExtraCleanup(t *testing.T) {
+	// A nil extraCleanup must be accepted; cleanup must still work.
+	cleanup := setupSignalHandler(-1, &term.State{}, nil)
+	cleanup()
+}
+
+// TestOpenTTYReader verifies openTTYReader returns a usable file in both the
+// /dev/tty-available and fallback-to-stdin cases. The shouldClose flag tells
+// the caller whether it owns the returned file.
+func TestOpenTTYReader(t *testing.T) {
+	f, shouldClose := openTTYReader()
+	if f == nil {
+		t.Fatal("expected a non-nil file")
+	}
+	if shouldClose {
+		// We own /dev/tty; close it to avoid leaking the descriptor.
+		f.Close()
+	}
+	// When shouldClose is false the returned file is os.Stdin, which the
+	// caller must not close.
+}

--- a/internal/pager/vim_test.go
+++ b/internal/pager/vim_test.go
@@ -319,6 +319,25 @@ func TestHistory(t *testing.T) {
 		}
 	})
 
+	t.Run("historyNext empty returns cur", func(t *testing.T) {
+		p := &pagerState{}
+		got := p.historyNext([]byte("keep"))
+		if string(got) != "keep" {
+			t.Errorf("got %q, want 'keep' when history empty", got)
+		}
+	})
+
+	t.Run("historyNext advances within range", func(t *testing.T) {
+		p := &pagerState{history: []string{"a", "b", "c"}, histIndex: 0}
+		got := p.historyNext(nil)
+		if string(got) != "b" {
+			t.Errorf("got %q, want 'b'", got)
+		}
+		if p.histIndex != 1 {
+			t.Errorf("histIndex = %d, want 1", p.histIndex)
+		}
+	})
+
 	t.Run("historyNext past end returns empty", func(t *testing.T) {
 		p := &pagerState{history: []string{"a", "b"}, histIndex: 1}
 		got := p.historyNext(nil)

--- a/internal/render/ansi_test.go
+++ b/internal/render/ansi_test.go
@@ -2,6 +2,8 @@ package render
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -143,5 +145,58 @@ func TestANSI_ZeroWidth(t *testing.T) {
 	}
 	if output == "" {
 		t.Fatal("expected non-empty output")
+	}
+}
+
+func TestANSI_AutoStyleWithTTY(t *testing.T) {
+	// auto/empty style with TTY=true exercises the termenv background
+	// detection branch (dark vs light) and the heading-prefix stripping.
+	md := "# Hello\n\nWorld\n"
+	for _, style := range []string{"", "auto"} {
+		t.Run("style="+style, func(t *testing.T) {
+			output, err := ANSI(md, RenderOptions{Width: 80, Style: style, TTY: true})
+			if err != nil {
+				t.Fatalf("ANSI() error: %v", err)
+			}
+			if !strings.Contains(output, "Hello") {
+				t.Errorf("expected heading text in output, got %q", output)
+			}
+			// withoutHeadingPrefix removes the leading "# " glamour prefix.
+			if strings.Contains(output, "# Hello") {
+				t.Errorf("heading prefix should be stripped, got %q", output)
+			}
+		})
+	}
+}
+
+func TestANSI_StandardNamedStyles(t *testing.T) {
+	md := "# Title\n\nbody text\n"
+	for _, style := range []string{"notty", "ascii", "dracula", "pink"} {
+		t.Run(style, func(t *testing.T) {
+			output, err := ANSI(md, RenderOptions{Width: 80, Style: style, TTY: true})
+			if err != nil {
+				t.Fatalf("ANSI(style=%q) error: %v", style, err)
+			}
+			if !strings.Contains(output, "Title") {
+				t.Errorf("style %q output missing title: %q", style, output)
+			}
+		})
+	}
+}
+
+func TestANSI_ValidStyleFile(t *testing.T) {
+	// A well-formed style JSON file must be loaded via WithStylesFromJSONFile.
+	dir := t.TempDir()
+	stylePath := filepath.Join(dir, "style.json")
+	if err := os.WriteFile(stylePath, []byte(`{"document":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	md := "# Hello\n\nWorld\n"
+	output, err := ANSI(md, RenderOptions{Width: 80, Style: stylePath, TTY: true})
+	if err != nil {
+		t.Fatalf("ANSI() with valid style file error: %v", err)
+	}
+	if !strings.Contains(output, "Hello") {
+		t.Errorf("expected heading text in output, got %q", output)
 	}
 }

--- a/internal/termimage/replace_test.go
+++ b/internal/termimage/replace_test.go
@@ -94,6 +94,17 @@ func TestStripANSI_TruncatedEscape(t *testing.T) {
 	}
 }
 
+func TestStripANSI_MalformedCSIBeforeTerminator(t *testing.T) {
+	// A new ESC arrives inside a CSI sequence before its letter terminator.
+	// The first (malformed) sequence is abandoned and the second is parsed,
+	// so only the visible text survives.
+	input := "\x1b[31\x1b[0mvisible"
+	got := stripANSI(input)
+	if got != "visible" {
+		t.Fatalf("expected 'visible', got %q", got)
+	}
+}
+
 func TestStripANSI_Mixed(t *testing.T) {
 	input := "\x1b[1mbold\x1b[0m and \x1b]8;;url\x07link\x1b]8;;\x07"
 	got := stripANSI(input)

--- a/internal/termimage/sixel_test.go
+++ b/internal/termimage/sixel_test.go
@@ -8,7 +8,30 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
+
+// withStdin temporarily replaces os.Stdin with a file containing the given
+// bytes, restoring the original on cleanup. Returns the replacement file.
+func withStdin(t *testing.T, data []byte) {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "stdin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdin
+	os.Stdin = f
+	t.Cleanup(func() {
+		os.Stdin = orig
+		f.Close()
+	})
+}
 
 func TestIsSixel_EnvOverride(t *testing.T) {
 	resetSixelCache()
@@ -129,6 +152,63 @@ func TestQuerySixelViaDA1_NonTTY(t *testing.T) {
 	// early-return path for CI environments.
 	if got := querySixelViaDA1(); got != false {
 		t.Fatalf("querySixelViaDA1() on non-TTY = %v, want false", got)
+	}
+}
+
+func TestReadDA1Response_FullResponse(t *testing.T) {
+	// A complete DA1 response (terminated by 'c') is read back verbatim.
+	withStdin(t, []byte("\x1b[?62;4;6c"))
+	resp, ok := readDA1Response(time.Second)
+	if !ok {
+		t.Fatal("expected ok=true for a terminated response")
+	}
+	if !bytes.ContainsRune(resp, 'c') {
+		t.Errorf("response %q missing terminator", resp)
+	}
+	if !parseSixelSupport(string(resp)) {
+		t.Errorf("expected attribute 4 to be detected in %q", resp)
+	}
+}
+
+func TestReadDA1Response_EOFWithoutTerminator(t *testing.T) {
+	// EOF reached after partial data (no 'c') still returns the buffered bytes.
+	withStdin(t, []byte("\x1b[?62;1"))
+	resp, ok := readDA1Response(time.Second)
+	if !ok {
+		t.Fatal("expected ok=true when partial data was buffered before EOF")
+	}
+	if string(resp) != "\x1b[?62;1" {
+		t.Errorf("resp = %q, want the buffered partial bytes", resp)
+	}
+}
+
+func TestReadDA1Response_EmptyEOF(t *testing.T) {
+	// Empty stdin reaches EOF with no data: ok must be false.
+	withStdin(t, nil)
+	resp, ok := readDA1Response(time.Second)
+	if ok {
+		t.Fatalf("expected ok=false on empty input, got resp=%q", resp)
+	}
+}
+
+// Note: the timeout path of readDA1Response is intentionally not unit-tested.
+// On timeout the reader goroutine remains blocked on os.Stdin.Read (documented
+// in sixel.go), which would race with restoring the swapped os.Stdin under the
+// -race detector. The timeout select branch is exercised indirectly in real
+// terminals where no DA1 response arrives.
+
+func TestDetectSixelUncached_EnvOverride(t *testing.T) {
+	t.Setenv("GLOWM_SIXEL", "1")
+	if !detectSixelUncached() {
+		t.Fatal("expected true when GLOWM_SIXEL=1")
+	}
+}
+
+func TestDetectSixelUncached_KnownTerminal(t *testing.T) {
+	t.Setenv("GLOWM_SIXEL", "")
+	t.Setenv("TERM_PROGRAM", "WezTerm")
+	if !detectSixelUncached() {
+		t.Fatal("expected true for WezTerm")
 	}
 }
 

--- a/internal/terminal/tty_test.go
+++ b/internal/terminal/tty_test.go
@@ -1,0 +1,41 @@
+package terminal
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsTTYFile_Nil(t *testing.T) {
+	if IsTTYFile(nil) {
+		t.Error("IsTTYFile(nil) should be false")
+	}
+}
+
+func TestIsTTYFile_RegularFile(t *testing.T) {
+	// A regular temp file is never a TTY.
+	f, err := os.CreateTemp(t.TempDir(), "notty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if IsTTYFile(f) {
+		t.Error("IsTTYFile(regular file) should be false")
+	}
+}
+
+func TestStdoutIsTTY_DoesNotPanic(t *testing.T) {
+	// Under `go test` stdout is generally not a TTY; the call must simply
+	// return a bool without panicking regardless of environment.
+	_ = StdoutIsTTY()
+	_ = StdinIsTTY()
+}
+
+func TestStdoutWidth_NonTTYReturnsDefault(t *testing.T) {
+	// When stdout is not a terminal (the usual test environment), the default
+	// width must be returned unchanged.
+	if !StdoutIsTTY() {
+		if got := StdoutWidth(123); got != 123 {
+			t.Errorf("StdoutWidth(123) on non-TTY = %d, want 123", got)
+		}
+	}
+}


### PR DESCRIPTION
## 目的

awesome-go 掲載基準（テストカバレッジ >= 80% かつカバレッジレポートのリンク提示）を満たすため、テストを拡充して総合カバレッジを 80% 以上に引き上げ、Codecov 連携を整備する。

## カバレッジ（before / after）

CI と同じ `go test -race -coverprofile=coverage.out ./...` で計測（CI build ジョブの "Total coverage" で確認）。

| パッケージ | before | after |
| --- | --- | --- |
| 総合 | 64.5% | **81.2%** |
| cmd/glowm | 未計測 (0%) | 52.3% |
| internal/config | 77.8% | 94.4% |
| internal/input | 81.5% | 88.9% |
| internal/markdown | 96.8% | 98.9% |
| internal/mermaid | 86.6% | 88.4% |
| internal/pager | 44.1% | 77.0% |
| internal/render | 80.0% | 92.5% |
| internal/termimage | 76.9% | 87.4% |
| internal/terminal | 未計測 (0%) | 63.6% |

## 追加した主なテスト（振る舞い・エッジケース・エラーパス中心）

- **internal/pager**: キー入力パーサ (`readKey` / `readEscapeKey`)、検索入力編集 (`readSearch` のバックスペース・履歴上下キー・キャンセル・制御文字無視・EOF)、`searchWord`、検索ナビゲーション (`n` / `N` / `*` / `#`)、画面描画 (`redraw` / `drawStatus` の位置表示・カーソル反転・検索ハイライト・ページ余白埋め)、`setupSignalHandler` のハンドラ登録 + cleanup、`openTTYReader`、ANSI ハイライトの index map 不一致 / 隣接マッチ、不正 CSI/OSC エスケープ、履歴ナビゲーション。pager 単体は 44.1% → 77.0%。
- **cmd/glowm**: `main()` をテスト可能な `run(args, stdout, stderr) int` にリファクタ。フラグ解析、`-version`、不正フラグ (exit 2)、ファイル描画 (非 TTY パス)、存在しないファイル / 入力なし (exit 1)、`-pdf` の mermaid なしエラーを検証。
- **internal/config**: `configPath()` が user config dir 配下の `glowm/config.json` を指すことを検証。
- **internal/render**: auto/empty スタイル + TTY の背景色判定分岐、名前付き標準スタイル (notty/ascii/dracula/pink)、有効な style JSON ファイル読み込み。
- **internal/termimage**: `readDA1Response` の完全応答 / 部分応答 EOF / 空 EOF、`detectSixelUncached` の env・既知端末分岐、`stripANSI` の不正 CSI 分岐。
- **internal/input**: stdin パイプありの引数なし読み込み、stdin 過大入力の拒否。
- **internal/markdown**: `fenceStart` / `isFenceEnd` の backtick/tilde・長さ・インデント・末尾空白の CommonMark ルール。
- **internal/terminal**: `IsTTYFile(nil)` / 通常ファイル、非 TTY 時の `StdoutWidth` デフォルト返却。

### テスト困難箇所（意図的に未カバー）

端末を直接操作する関数 (`pageMore` / `pageVim` / `terminalHeight` / `terminalWidth`、`StdoutWidth` の TTY 分岐) は実 TTY/PTY が必要なため単体テスト対象外。純粋ロジック（キー処理・検索・描画）を切り出してテストし、総合 80% 超を Chrome 非依存で達成した。`readDA1Response` のタイムアウト分岐、および `setupSignalHandler` のシグナル受信分岐 (`os.Exit` を呼ぶ) も意図的に未カバー。

なお headless Chrome を起動する `runPDF` 成功パスは CI で websocket timeout により不安定だったため、cmd/glowm からは外した（`RenderPDF` 自体は internal/mermaid 側でテスト済み）。代わりに Chrome 非依存の pager 純粋ロジックでカバレッジを確保し、Chrome の不安定さに左右されない 81.2% のマージンを確保している。

## Codecov 連携

- CI (`.github/workflows/ci.yml`) の coverprofile 生成ステップ直後に `codecov/codecov-action@v5`（SHA ピン留め: `5a1091511ad55cbe89839c7260b706298ca349f7` = v5.5.1）でアップロードするステップを追加。既存の "Check coverage" 閾値ステップはそのまま維持。pinact チェックも pass。
- README タイトル直下に codecov バッジを追加。
- `coverage.out` を .gitignore に追加。

## Test plan

- [x] `go build ./...` pass（ローカル + CI）
- [x] `go vet ./...` pass
- [x] `go test -race -coverprofile=coverage.out ./...` 全パッケージ pass（ローカル + CI build ジョブ）
- [x] CI build ジョブの "Total coverage" が 81.2%（>= 80%）であることを確認
- [x] 追加・変更した Go ファイルが `gofmt` クリーン
- [x] CI 全チェック（build / pinact / dependency-review）pass

## ⚠️ ユーザー操作（マージ後）

codecov.io のバッジとレポートを有効化するには以下が必要です。完了するまでバッジは unknown 表示になります（現状 CI の Codecov アップロードは `Token required - not valid tokenless upload` で失敗していますが、ビルドは緑のまま）。

1. https://codecov.io に atani でログイン
2. 当リポジトリ (atani/glowm) を有効化
3. `CODECOV_TOKEN` をリポジトリ secrets に登録（推奨）
