### PR TITLE
fix: account for Mermaid image height in more pager

### DIFF
--- a/cmd/glowm/main.go
+++ b/cmd/glowm/main.go
@@ -183,11 +183,7 @@ func runWithImages(md string, opts options, stdoutTTY bool, imageFormat termimag
 		return true, fail(stderr, err)
 	}
 	if shouldUsePager {
-		if pagerMode == pager.ModeMore {
-			output = termimage.ReplaceMarkersWithImagesForPager(output, result.Markers, images, imageFormat, w)
-		} else {
-			output = termimage.ReplaceMarkersWithImages(output, result.Markers, images, imageFormat, w)
-		}
+		output = replaceMarkersForPagerMode(output, result.Markers, images, imageFormat, w, pagerMode)
 		if err := pager.PageWithMode(output, pagerMode); err != nil {
 			return true, fail(stderr, err)
 		}
@@ -198,6 +194,13 @@ func runWithImages(md string, opts options, stdoutTTY bool, imageFormat termimag
 		return true, fail(stderr, err)
 	}
 	return true, 0
+}
+
+func replaceMarkersForPagerMode(output string, markers []string, images [][]byte, imageFormat termimage.Format, width int, pagerMode pager.Mode) string {
+	if pagerMode == pager.ModeMore {
+		return termimage.ReplaceMarkersWithImagesForPager(output, markers, images, imageFormat, width)
+	}
+	return termimage.ReplaceMarkersWithImages(output, markers, images, imageFormat, width)
 }
 
 // fail writes a formatted error to stderr and returns exit code 1.

--- a/cmd/glowm/main.go
+++ b/cmd/glowm/main.go
@@ -182,13 +182,18 @@ func runWithImages(md string, opts options, stdoutTTY bool, imageFormat termimag
 	if err != nil {
 		return true, fail(stderr, err)
 	}
-	output = termimage.ReplaceMarkersWithImages(output, result.Markers, images, imageFormat, w)
 	if shouldUsePager {
+		if pagerMode == pager.ModeMore {
+			output = termimage.ReplaceMarkersWithImagesForPager(output, result.Markers, images, imageFormat, w)
+		} else {
+			output = termimage.ReplaceMarkersWithImages(output, result.Markers, images, imageFormat, w)
+		}
 		if err := pager.PageWithMode(output, pagerMode); err != nil {
 			return true, fail(stderr, err)
 		}
 		return true, 0
 	}
+	output = termimage.ReplaceMarkersWithImages(output, result.Markers, images, imageFormat, w)
 	if _, err := fmt.Fprint(stdout, output); err != nil {
 		return true, fail(stderr, err)
 	}

--- a/cmd/glowm/main_test.go
+++ b/cmd/glowm/main_test.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/atani/glowm/internal/pager"
+	"github.com/atani/glowm/internal/termimage"
 )
 
 func TestParseFlags_Defaults(t *testing.T) {
@@ -148,5 +151,21 @@ func TestRunPDF_NoMermaidBlocks(t *testing.T) {
 	}
 	if !strings.Contains(errBuf.String(), "no mermaid blocks") {
 		t.Errorf("stderr = %q, want 'no mermaid blocks'", errBuf.String())
+	}
+}
+
+func TestReplaceMarkersForPagerMode(t *testing.T) {
+	markers := []string{"GLOWM_MERMAID_0"}
+	images := [][]byte{[]byte("png")}
+	output := "GLOWM_MERMAID_0"
+
+	more := replaceMarkersForPagerMode(output, markers, images, termimage.FormatKitty, 80, pager.ModeMore)
+	if !strings.Contains(more, "glowm-rows=1") {
+		t.Fatalf("more mode should include pager row metadata: %q", more)
+	}
+
+	vim := replaceMarkersForPagerMode(output, markers, images, termimage.FormatKitty, 80, pager.ModeVim)
+	if strings.Contains(vim, "glowm-rows=") {
+		t.Fatalf("vim mode should not include pager row metadata: %q", vim)
 	}
 }

--- a/internal/pager/more.go
+++ b/internal/pager/more.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"golang.org/x/term"
@@ -19,7 +20,7 @@ func pageMore(output string) error {
 		return printOutput(output)
 	}
 
-	lines := strings.Split(output, "\n")
+	lines, heights := splitDisplayLines(output)
 	reader, shouldClose := openTTYReader()
 	if shouldClose {
 		defer reader.Close()
@@ -48,10 +49,7 @@ func pageMore(output string) error {
 			fmt.Fprint(writer, ansiClearScreen)
 			shouldClearScreen = false
 		}
-		end := linePos + linesPerPage
-		if end > len(lines) {
-			end = len(lines)
-		}
+		end := pageEnd(heights, linePos, linesPerPage)
 		for j := linePos; j < end; j++ {
 			fmt.Fprint(writer, "\r")
 			fmt.Fprint(writer, lines[j])
@@ -90,4 +88,57 @@ func pageMore(output string) error {
 			// ignore other keys
 		}
 	}
+}
+
+func splitDisplayLines(output string) ([]string, []int) {
+	lines := strings.Split(output, "\n")
+	heights := make([]int, len(lines))
+	for i, line := range lines {
+		clean, rows := consumePagerRowsMarker(line)
+		lines[i] = clean
+		heights[i] = rows
+	}
+	return lines, heights
+}
+
+func pageEnd(heights []int, start, linesPerPage int) int {
+	if start >= len(heights) {
+		return len(heights)
+	}
+	used := 0
+	for end := start; end < len(heights); end++ {
+		rows := heights[end]
+		if rows < 1 {
+			rows = 1
+		}
+		if used > 0 && used+rows > linesPerPage {
+			return end
+		}
+		used += rows
+		if used >= linesPerPage {
+			return end + 1
+		}
+	}
+	return len(heights)
+}
+
+func consumePagerRowsMarker(line string) (string, int) {
+	const prefix = "\x1b]1337;glowm-rows="
+	start := strings.Index(line, prefix)
+	if start == -1 {
+		return line, 1
+	}
+	valueStart := start + len(prefix)
+	valueEnd := valueStart
+	for valueEnd < len(line) && line[valueEnd] >= '0' && line[valueEnd] <= '9' {
+		valueEnd++
+	}
+	if valueEnd == valueStart || valueEnd >= len(line) || line[valueEnd] != '\x07' {
+		return line, 1
+	}
+	rows, err := strconv.Atoi(line[valueStart:valueEnd])
+	if err != nil || rows < 1 {
+		rows = 1
+	}
+	return line[:start] + line[valueEnd+1:], rows
 }

--- a/internal/pager/render_test.go
+++ b/internal/pager/render_test.go
@@ -118,6 +118,12 @@ func TestPageEnd_AccountsForDisplayRows(t *testing.T) {
 	if got := pageEnd(heights, 2, 4); got != 3 {
 		t.Fatalf("pageEnd() = %d, want 3 so oversized first item still renders", got)
 	}
+	if got := pageEnd(heights, len(heights), 4); got != len(heights) {
+		t.Fatalf("pageEnd() = %d, want len(heights)", got)
+	}
+	if got := pageEnd([]int{1, 1}, 0, 4); got != 2 {
+		t.Fatalf("pageEnd() = %d, want all lines when they fit", got)
+	}
 }
 
 func TestSplitDisplayLines_ConsumesPagerRowsMarker(t *testing.T) {
@@ -128,5 +134,22 @@ func TestSplitDisplayLines_ConsumesPagerRowsMarker(t *testing.T) {
 	}
 	if heights[0] != 1 || heights[1] != 7 || heights[2] != 1 {
 		t.Fatalf("unexpected heights: %#v", heights)
+	}
+}
+
+func TestConsumePagerRowsMarker_InvalidMarkers(t *testing.T) {
+	tests := []string{
+		"plain",
+		"\x1b]1337;glowm-rows=\x07image",
+		"\x1b]1337;glowm-rows=0\x07image",
+		"\x1b]1337;glowm-rows=7image",
+	}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, rows := consumePagerRowsMarker(input)
+			if rows != 1 {
+				t.Fatalf("rows = %d, want 1", rows)
+			}
+		})
 	}
 }

--- a/internal/pager/render_test.go
+++ b/internal/pager/render_test.go
@@ -108,3 +108,25 @@ func TestPrintOutput(t *testing.T) {
 		t.Errorf("printOutput(empty) error: %v", err)
 	}
 }
+
+func TestPageEnd_AccountsForDisplayRows(t *testing.T) {
+	heights := []int{1, 1, 5, 1}
+
+	if got := pageEnd(heights, 0, 4); got != 2 {
+		t.Fatalf("pageEnd() = %d, want 2 so tall image starts next page", got)
+	}
+	if got := pageEnd(heights, 2, 4); got != 3 {
+		t.Fatalf("pageEnd() = %d, want 3 so oversized first item still renders", got)
+	}
+}
+
+func TestSplitDisplayLines_ConsumesPagerRowsMarker(t *testing.T) {
+	lines, heights := splitDisplayLines("a\n\x1b]1337;glowm-rows=7\x07image\nb")
+
+	if len(lines) != 3 || lines[1] != "image" {
+		t.Fatalf("unexpected lines: %#v", lines)
+	}
+	if heights[0] != 1 || heights[1] != 7 || heights[2] != 1 {
+		t.Fatalf("unexpected heights: %#v", heights)
+	}
+}

--- a/internal/termimage/replace.go
+++ b/internal/termimage/replace.go
@@ -1,10 +1,23 @@
 package termimage
 
 import (
+	"bytes"
+	"image"
+	_ "image/png"
+	"math"
+	"strconv"
 	"strings"
 )
 
 func ReplaceMarkersWithImages(output string, markers []string, images [][]byte, format Format, widthCells int) string {
+	return replaceMarkersWithImages(output, markers, images, format, widthCells, false)
+}
+
+func ReplaceMarkersWithImagesForPager(output string, markers []string, images [][]byte, format Format, widthCells int) string {
+	return replaceMarkersWithImages(output, markers, images, format, widthCells, true)
+}
+
+func replaceMarkersWithImages(output string, markers []string, images [][]byte, format Format, widthCells int, padToImageRows bool) string {
 	if len(markers) == 0 || len(images) == 0 {
 		return output
 	}
@@ -17,6 +30,9 @@ func ReplaceMarkersWithImages(output string, markers []string, images [][]byte, 
 		if img == "" {
 			continue
 		}
+		if padToImageRows {
+			img = pagerRowsMarker(imageRows(images[i], widthCells)) + img
+		}
 		lookup[marker] = img
 	}
 
@@ -28,6 +44,26 @@ func ReplaceMarkersWithImages(output string, markers []string, images [][]byte, 
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+func pagerRowsMarker(rows int) string {
+	return "\x1b]1337;glowm-rows=" + strconv.Itoa(rows) + "\x07"
+}
+
+func imageRows(png []byte, widthCells int) int {
+	if widthCells <= 0 {
+		return 1
+	}
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(png))
+	if err != nil || cfg.Width <= 0 || cfg.Height <= 0 {
+		return 1
+	}
+	const cellAspect = 2.0 // terminal cells are roughly twice as tall as wide.
+	rows := int(math.Ceil((float64(cfg.Height) / float64(cfg.Width)) * float64(widthCells) / cellAspect))
+	if rows < 1 {
+		return 1
+	}
+	return rows
 }
 
 func stripANSI(s string) string {

--- a/internal/termimage/replace_test.go
+++ b/internal/termimage/replace_test.go
@@ -89,6 +89,18 @@ func TestReplaceMarkersWithImages_DoesNotPadImageRows(t *testing.T) {
 	}
 }
 
+func TestImageRows_Fallbacks(t *testing.T) {
+	if got := imageRows(pngFixture(t, 100, 100), 0); got != 1 {
+		t.Fatalf("imageRows(width=0) = %d, want 1", got)
+	}
+	if got := imageRows([]byte("not png"), 80); got != 1 {
+		t.Fatalf("imageRows(invalid png) = %d, want 1", got)
+	}
+	if got := imageRows(pngFixture(t, 100, 1), 1); got != 1 {
+		t.Fatalf("imageRows(tiny image) = %d, want minimum 1", got)
+	}
+}
+
 func TestStripANSI_NoEscapes(t *testing.T) {
 	input := "hello world"
 	if got := stripANSI(input); got != input {

--- a/internal/termimage/replace_test.go
+++ b/internal/termimage/replace_test.go
@@ -1,6 +1,10 @@
 package termimage
 
 import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
 	"strings"
 	"testing"
 )
@@ -52,6 +56,36 @@ func TestReplaceMarkersWithImages_FormatNone(t *testing.T) {
 	result := ReplaceMarkersWithImages(output, markers, images, FormatNone, 80)
 	if result != output {
 		t.Fatalf("expected unchanged output for FormatNone, got %q", result)
+	}
+}
+
+func TestReplaceMarkersWithImagesForPager_AddsImageRowMarker(t *testing.T) {
+	markers := []string{"GLOWM_MERMAID_0"}
+	images := [][]byte{pngFixture(t, 100, 100)}
+	output := "before\nGLOWM_MERMAID_0\nafter"
+
+	result := ReplaceMarkersWithImagesForPager(output, markers, images, FormatKitty, 80)
+
+	if strings.Contains(result, "GLOWM_MERMAID_0") {
+		t.Fatal("expected marker to be replaced")
+	}
+	if !strings.Contains(result, "\x1b]1337;glowm-rows=40\x07") {
+		t.Fatalf("expected pager row marker, got %q", result)
+	}
+	if got := strings.Count(result, "\n"); got != 2 {
+		t.Fatalf("expected pager replacement to preserve line count, got %d newlines", got)
+	}
+}
+
+func TestReplaceMarkersWithImages_DoesNotPadImageRows(t *testing.T) {
+	markers := []string{"GLOWM_MERMAID_0"}
+	images := [][]byte{pngFixture(t, 100, 100)}
+	output := "before\nGLOWM_MERMAID_0\nafter"
+
+	result := ReplaceMarkersWithImages(output, markers, images, FormatKitty, 80)
+
+	if got := strings.Count(result, "\n"); got != 2 {
+		t.Fatalf("expected normal replacement to preserve line count, got %d newlines", got)
 	}
 }
 
@@ -165,4 +199,15 @@ func TestStripANSI_DCS(t *testing.T) {
 	if got != "visible" {
 		t.Fatalf("expected 'visible', got %q", got)
 	}
+}
+
+func pngFixture(t *testing.T, width, height int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	img.Set(0, 0, color.White)
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
 }


### PR DESCRIPTION
## Summary
- Account for rendered Mermaid image height when paging in more mode
- Add pager-only image row metadata and page-boundary calculation
- Cover the row-height behavior with pager and terminal image tests

## Root Cause
The more pager counted each rendered output line as one terminal row. Inline Mermaid images can occupy many terminal rows. A page could overflow the terminal before the pager prompt appeared.

## Testing
- go test ./internal/pager ./internal/termimage ./cmd/glowm
- go test ./...

Fixes #58