### PR TITLE
feat: less pager mode with smooth Kitty image scrolling and Mermaid theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,35 @@ Example:
 ```json
 {
   "pager": {
-    "mode": "vim"
+    "mode": "less"
+  },
+  "mermaid": {
+    "theme": "auto"
   }
 }
 ```
+
+### `pager.mode`
+
+How the interactive pager behaves (default: `less`).
+
+- `less` — scrolls a line at a time (`j`/`k`, arrows, mouse wheel), with
+  half-page (`d`/`u`), page (`space`/`b`), `g`/`G` for top/bottom, and `/` `?`
+  `n` `N` search. On Kitty-graphics terminals (Kitty, Ghostty), inline Mermaid
+  diagrams scroll smoothly along with the text. This is the default.
+- `more` — simple forward paging (`space` to advance, `b` to go back).
+- `vim` — full-screen pager with a moving cursor line and Vim-style motions.
+
+### `mermaid.theme`
+
+Color theme for rendered Mermaid diagrams, applied to both inline images and
+`--pdf` export (default: `auto`).
+
+- `auto` — detect the terminal background and use `dark` on a dark background,
+  otherwise the light default. Falls back to light when the background can't be
+  detected (for example when exporting a PDF to a file). This is the default.
+- `light` (alias `default`), `dark`, `forest`, `neutral`, `base` — force a
+  specific [Mermaid theme](https://mermaid.js.org/config/theming.html).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Chrome or Chromium is required for Mermaid rendering and PDF export.
 - `--no-pager` Disable default pager; pager is on by default for TTY
 - `--pdf` Export Mermaid diagrams to PDF via stdout
 - `--show-link-urls` Show raw link URLs instead of just the link text (see [Links](#links))
+- `--watch` Watch the input file and re-render the pager when it changes (requires a file argument and a terminal)
+- `--no-watch` Disable watch, overriding the config default
 - `--version` Show version information
 
 ## Links
@@ -120,7 +122,8 @@ Example:
 ```json
 {
   "pager": {
-    "mode": "less"
+    "mode": "less",
+    "watch": false
   },
   "mermaid": {
     "theme": "auto"
@@ -138,6 +141,15 @@ How the interactive pager behaves (default: `less`).
   diagrams scroll smoothly along with the text. This is the default.
 - `more` — simple forward paging (`space` to advance, `b` to go back).
 - `vim` — full-screen pager with a moving cursor line and Vim-style motions.
+
+### `pager.watch`
+
+When `true`, glowm watches the input file and re-renders the pager in place
+whenever the file changes — useful for editing a doc in one pane and previewing
+it in another (default: `false`). Equivalent to passing `--watch`; use
+`--no-watch` to override a `true` config for a single run. Only applies when
+reading a file (not stdin) to a terminal; otherwise glowm renders once and
+prints a note. Watch uses the `less` pager.
 
 ### `mermaid.theme`
 

--- a/cmd/glowm/main.go
+++ b/cmd/glowm/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/atani/glowm/internal/render"
 	"github.com/atani/glowm/internal/termimage"
 	"github.com/atani/glowm/internal/terminal"
+	"github.com/atani/glowm/internal/watch"
 )
 
 // Version information (set by goreleaser ldflags)
@@ -34,6 +35,8 @@ type options struct {
 	pdf          bool
 	showVersion  bool
 	showLinkURLs bool
+	watch        bool
+	noWatch      bool
 	positional   []string
 }
 
@@ -48,6 +51,8 @@ func parseFlags(args []string) (options, error) {
 	fs.BoolVar(&opts.pdf, "pdf", false, "output mermaid diagrams as PDF to stdout")
 	fs.BoolVar(&opts.showVersion, "version", false, "show version information")
 	fs.BoolVar(&opts.showLinkURLs, "show-link-urls", false, "show raw link URLs instead of just the link text")
+	fs.BoolVar(&opts.watch, "watch", false, "watch the input file and re-render on changes")
+	fs.BoolVar(&opts.noWatch, "no-watch", false, "disable watch (overrides config)")
 	if err := fs.Parse(args); err != nil {
 		return options{}, err
 	}
@@ -101,6 +106,22 @@ func run(args []string, stdout, stderr io.Writer) int {
 		pagerMode = pager.ModeMore
 	}
 	shouldUsePager := opts.usePager || (stdoutTTY && !opts.noPager)
+
+	// Watch mode re-renders and refreshes the pager when the file changes. It
+	// only applies to a real file rendered to a terminal; otherwise fall back to
+	// a one-shot render with a note.
+	shouldWatch := opts.watch || (cfg.Pager.Watch && !opts.noWatch)
+	if shouldWatch {
+		filePath := ""
+		if len(opts.positional) == 1 && opts.positional[0] != "-" {
+			filePath = opts.positional[0]
+		}
+		if filePath == "" || !stdoutTTY {
+			fmt.Fprintln(stderr, "glowm: watch ignored (requires a file argument and a terminal)")
+		} else {
+			return runWatch(filePath, opts, imageFormat, cfg.Mermaid.Theme, stderr)
+		}
+	}
 
 	if stdoutTTY && imageFormat != termimage.FormatNone {
 		handled, code := runWithImages(md, opts, stdoutTTY, imageFormat, pagerMode, shouldUsePager, cfg.Mermaid.Theme, stdout, stderr)
@@ -211,6 +232,80 @@ func runWithImages(md string, opts options, stdoutTTY bool, imageFormat termimag
 		return true, fail(stderr, err)
 	}
 	return true, 0
+}
+
+// runWatch renders path and keeps the less pager open, re-rendering and
+// refreshing in place whenever the file changes. Uses the smooth Kitty pager on
+// Kitty-graphics terminals and the text pager elsewhere.
+func runWatch(path string, opts options, imageFormat termimage.Format, mermaidTheme string, stderr io.Writer) int {
+	w := opts.width
+	if w == 0 {
+		w = terminal.StdoutWidth(80)
+	}
+	kitty := imageFormat == termimage.FormatKitty
+	theme := effectiveMermaidTheme(mermaidTheme)
+
+	// Resolve "auto" to a concrete style now, before the pager takes the
+	// terminal into raw mode. Re-rendering with "auto" on each reload would make
+	// glamour re-query the terminal background mid-pager, racing our input
+	// reader and flipping the text theme.
+	style := opts.style
+	if s := strings.TrimSpace(style); s == "" || strings.EqualFold(s, "auto") {
+		style = render.AutoStyle()
+	}
+
+	renderContent := func() (pager.Content, error) {
+		md, err := input.Read([]string{path})
+		if err != nil {
+			return pager.Content{}, err
+		}
+		if kitty {
+			res, err := markdown.ExtractMermaidWithMarkers(md)
+			if err != nil {
+				return pager.Content{}, err
+			}
+			if len(res.Blocks) > 0 {
+				if images, rerr := mermaid.RenderPNGs(res.Blocks, w, theme); rerr == nil {
+					out, err := render.ANSI(res.Markdown, render.RenderOptions{Width: w, Style: style, TTY: true, ShowLinkURLs: opts.showLinkURLs})
+					if err != nil {
+						return pager.Content{}, err
+					}
+					return pager.Content{Output: out, Markers: res.Markers, Images: images, WidthCells: w}, nil
+				}
+				// Mermaid render failed; fall through to plain text rendering so
+				// diagrams degrade to code blocks rather than showing raw markers.
+			}
+		}
+		res, err := markdown.ExtractMermaid(md, true)
+		if err != nil {
+			return pager.Content{}, err
+		}
+		out, err := render.ANSI(res.Markdown, render.RenderOptions{Width: w, Style: style, TTY: true, ShowLinkURLs: opts.showLinkURLs})
+		if err != nil {
+			return pager.Content{}, err
+		}
+		return pager.Content{Output: out}, nil
+	}
+
+	initial, err := renderContent()
+	if err != nil {
+		return fail(stderr, err)
+	}
+
+	watcher := watch.New(path, 0, 0)
+	watcher.Start()
+	defer watcher.Stop()
+
+	if kitty {
+		if err := pager.PageLessKittyWatch(initial, watcher.C, renderContent); err != nil {
+			return fail(stderr, err)
+		}
+	} else {
+		if err := pager.PageLessWatch(initial, watcher.C, renderContent); err != nil {
+			return fail(stderr, err)
+		}
+	}
+	return 0
 }
 
 func replaceMarkersForPagerMode(output string, markers []string, images [][]byte, imageFormat termimage.Format, width int, pagerMode pager.Mode) string {

--- a/cmd/glowm/main.go
+++ b/cmd/glowm/main.go
@@ -83,14 +83,18 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return fail(stderr, err)
 	}
 
+	cfg := config.Load()
+	if !mermaid.IsKnownTheme(cfg.Mermaid.Theme) {
+		fmt.Fprintf(stderr, "glowm: unknown mermaid theme %q, using default\n", cfg.Mermaid.Theme)
+	}
+
 	if opts.pdf {
-		return runPDF(md, stdout, stderr)
+		return runPDF(md, cfg.Mermaid.Theme, stdout, stderr)
 	}
 
 	stdoutTTY := terminal.StdoutIsTTY()
 	imageFormat := termimage.Detect()
 
-	cfg := config.Load()
 	pagerMode := pager.Mode(strings.ToLower(cfg.Pager.Mode))
 	if !pager.ValidMode(pagerMode) {
 		fmt.Fprintf(stderr, "glowm: unknown pager mode %q, using more\n", cfg.Pager.Mode)
@@ -99,7 +103,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	shouldUsePager := opts.usePager || (stdoutTTY && !opts.noPager)
 
 	if stdoutTTY && imageFormat != termimage.FormatNone {
-		handled, code := runWithImages(md, opts, stdoutTTY, imageFormat, pagerMode, shouldUsePager, stdout, stderr)
+		handled, code := runWithImages(md, opts, stdoutTTY, imageFormat, pagerMode, shouldUsePager, cfg.Mermaid.Theme, stdout, stderr)
 		if handled {
 			return code
 		}
@@ -139,7 +143,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 }
 
 // runPDF renders mermaid blocks to PDF bytes written to stdout.
-func runPDF(md string, stdout, stderr io.Writer) int {
+func runPDF(md, mermaidTheme string, stdout, stderr io.Writer) int {
 	result, err := markdown.ExtractMermaid(md, false)
 	if err != nil {
 		return fail(stderr, err)
@@ -147,7 +151,7 @@ func runPDF(md string, stdout, stderr io.Writer) int {
 	if len(result.Blocks) == 0 {
 		return fail(stderr, errors.New("no mermaid blocks found"))
 	}
-	pdfBytes, err := mermaid.RenderPDF(result.Blocks)
+	pdfBytes, err := mermaid.RenderPDF(result.Blocks, mermaidTheme)
 	if err != nil {
 		return fail(stderr, err)
 	}
@@ -160,7 +164,7 @@ func runPDF(md string, stdout, stderr io.Writer) int {
 // runWithImages renders markdown with inline terminal images. It returns
 // handled=false when there are no mermaid blocks or rendering fails, so the
 // caller can fall back to the text-only path.
-func runWithImages(md string, opts options, stdoutTTY bool, imageFormat termimage.Format, pagerMode pager.Mode, shouldUsePager bool, stdout, stderr io.Writer) (handled bool, code int) {
+func runWithImages(md string, opts options, stdoutTTY bool, imageFormat termimage.Format, pagerMode pager.Mode, shouldUsePager bool, mermaidTheme string, stdout, stderr io.Writer) (handled bool, code int) {
 	result, err := markdown.ExtractMermaidWithMarkers(md)
 	if err != nil {
 		return true, fail(stderr, err)
@@ -172,7 +176,7 @@ func runWithImages(md string, opts options, stdoutTTY bool, imageFormat termimag
 	if w == 0 {
 		w = terminal.StdoutWidth(80)
 	}
-	images, renderErr := mermaid.RenderPNGs(result.Blocks, w)
+	images, renderErr := mermaid.RenderPNGs(result.Blocks, w, mermaidTheme)
 	if renderErr != nil {
 		fmt.Fprintf(stderr, "warning: mermaid rendering failed: %v\n", renderErr)
 		return false, 0
@@ -187,6 +191,15 @@ func runWithImages(md string, opts options, stdoutTTY bool, imageFormat termimag
 		return true, fail(stderr, err)
 	}
 	if shouldUsePager {
+		// less mode on a Kitty-graphics terminal scrolls images smoothly by
+		// cropping them per row, so it needs the raw images and the unmodified
+		// marker lines rather than pre-baked image escapes.
+		if pagerMode == pager.ModeLess && imageFormat == termimage.FormatKitty {
+			if err := pager.PageLessKitty(output, result.Markers, images, w); err != nil {
+				return true, fail(stderr, err)
+			}
+			return true, 0
+		}
 		output = replaceMarkersForPagerMode(output, result.Markers, images, imageFormat, w, pagerMode)
 		if err := pager.PageWithMode(output, pagerMode); err != nil {
 			return true, fail(stderr, err)
@@ -201,7 +214,7 @@ func runWithImages(md string, opts options, stdoutTTY bool, imageFormat termimag
 }
 
 func replaceMarkersForPagerMode(output string, markers []string, images [][]byte, imageFormat termimage.Format, width int, pagerMode pager.Mode) string {
-	if pagerMode == pager.ModeMore {
+	if pagerMode == pager.ModeMore || pagerMode == pager.ModeLess {
 		return termimage.ReplaceMarkersWithImagesForPager(output, markers, images, imageFormat, width)
 	}
 	return termimage.ReplaceMarkersWithImages(output, markers, images, imageFormat, width)

--- a/cmd/glowm/main.go
+++ b/cmd/glowm/main.go
@@ -151,7 +151,7 @@ func runPDF(md, mermaidTheme string, stdout, stderr io.Writer) int {
 	if len(result.Blocks) == 0 {
 		return fail(stderr, errors.New("no mermaid blocks found"))
 	}
-	pdfBytes, err := mermaid.RenderPDF(result.Blocks, mermaidTheme)
+	pdfBytes, err := mermaid.RenderPDF(result.Blocks, effectiveMermaidTheme(mermaidTheme))
 	if err != nil {
 		return fail(stderr, err)
 	}
@@ -176,7 +176,7 @@ func runWithImages(md string, opts options, stdoutTTY bool, imageFormat termimag
 	if w == 0 {
 		w = terminal.StdoutWidth(80)
 	}
-	images, renderErr := mermaid.RenderPNGs(result.Blocks, w, mermaidTheme)
+	images, renderErr := mermaid.RenderPNGs(result.Blocks, w, effectiveMermaidTheme(mermaidTheme))
 	if renderErr != nil {
 		fmt.Fprintf(stderr, "warning: mermaid rendering failed: %v\n", renderErr)
 		return false, 0
@@ -218,6 +218,21 @@ func replaceMarkersForPagerMode(output string, markers []string, images [][]byte
 		return termimage.ReplaceMarkersWithImagesForPager(output, markers, images, imageFormat, width)
 	}
 	return termimage.ReplaceMarkersWithImages(output, markers, images, imageFormat, width)
+}
+
+// effectiveMermaidTheme resolves the configured theme. "auto" (or empty) becomes
+// "dark" or "default" based on the detected terminal background; any explicit
+// theme is passed through unchanged. Detection falls back to the light default
+// when the background can't be determined (e.g. output is not a terminal, as
+// when exporting a PDF to a file).
+func effectiveMermaidTheme(configured string) string {
+	if configured != "" && !strings.EqualFold(configured, "auto") {
+		return configured
+	}
+	if dark, ok := terminal.BackgroundIsDark(); ok && dark {
+		return "dark"
+	}
+	return "default"
 }
 
 // fail writes a formatted error to stderr and returns exit code 1.

--- a/cmd/glowm/main_test.go
+++ b/cmd/glowm/main_test.go
@@ -155,7 +155,7 @@ func TestRun_PDFFlagNoBlocks(t *testing.T) {
 
 func TestRunPDF_NoMermaidBlocks(t *testing.T) {
 	var out, errBuf bytes.Buffer
-	code := runPDF("# Just text, no diagrams\n", &out, &errBuf)
+	code := runPDF("# Just text, no diagrams\n", "", &out, &errBuf)
 	if code != 1 {
 		t.Errorf("code = %d, want 1 when no mermaid blocks", code)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,12 +9,20 @@ import (
 
 // Config holds the application configuration.
 type Config struct {
-	Pager PagerConfig `json:"pager"`
+	Pager   PagerConfig   `json:"pager"`
+	Mermaid MermaidConfig `json:"mermaid"`
 }
 
 // PagerConfig holds pager-specific settings.
 type PagerConfig struct {
 	Mode string `json:"mode"`
+}
+
+// MermaidConfig holds Mermaid diagram rendering settings.
+type MermaidConfig struct {
+	// Theme selects the Mermaid color theme: "light"/"default", "dark",
+	// "forest", "neutral", or "base". Empty means default.
+	Theme string `json:"theme"`
 }
 
 // configPathFunc is the function used to determine the config file path.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,10 @@ var configPathFunc = configPath
 func Load() Config {
 	defaultCfg := Config{
 		Pager: PagerConfig{
-			Mode: "more",
+			Mode: "less",
+		},
+		Mermaid: MermaidConfig{
+			Theme: "auto",
 		},
 	}
 
@@ -54,7 +57,10 @@ func Load() Config {
 		return defaultCfg
 	}
 	if cfg.Pager.Mode == "" {
-		cfg.Pager.Mode = "more"
+		cfg.Pager.Mode = "less"
+	}
+	if cfg.Mermaid.Theme == "" {
+		cfg.Mermaid.Theme = "auto"
 	}
 	return cfg
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,9 @@ type Config struct {
 // PagerConfig holds pager-specific settings.
 type PagerConfig struct {
 	Mode string `json:"mode"`
+	// Watch re-renders and refreshes the pager when the input file changes.
+	// Only applies when reading a file (not stdin) to a terminal.
+	Watch bool `json:"watch"`
 }
 
 // MermaidConfig holds Mermaid diagram rendering settings.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -29,8 +29,11 @@ func TestLoad_DefaultsWhenNoFile(t *testing.T) {
 	t.Cleanup(func() { configPathFunc = origFunc })
 
 	cfg := Load()
-	if cfg.Pager.Mode != "more" {
-		t.Errorf("default mode = %q, want %q", cfg.Pager.Mode, "more")
+	if cfg.Pager.Mode != "less" {
+		t.Errorf("default mode = %q, want %q", cfg.Pager.Mode, "less")
+	}
+	if cfg.Mermaid.Theme != "auto" {
+		t.Errorf("default theme = %q, want %q", cfg.Mermaid.Theme, "auto")
 	}
 }
 
@@ -42,19 +45,19 @@ func TestLoad_VimMode(t *testing.T) {
 	}
 }
 
-func TestLoad_EmptyModeDefaultsToMore(t *testing.T) {
+func TestLoad_EmptyModeDefaultsToLess(t *testing.T) {
 	setupTestConfig(t, `{"pager": {"mode": ""}}`)
 	cfg := Load()
-	if cfg.Pager.Mode != "more" {
-		t.Errorf("mode = %q, want %q", cfg.Pager.Mode, "more")
+	if cfg.Pager.Mode != "less" {
+		t.Errorf("mode = %q, want %q", cfg.Pager.Mode, "less")
 	}
 }
 
 func TestLoad_InvalidJSON(t *testing.T) {
 	setupTestConfig(t, `{invalid json}`)
 	cfg := Load()
-	if cfg.Pager.Mode != "more" {
-		t.Errorf("mode = %q, want %q on invalid JSON", cfg.Pager.Mode, "more")
+	if cfg.Pager.Mode != "less" {
+		t.Errorf("mode = %q, want %q on invalid JSON", cfg.Pager.Mode, "less")
 	}
 }
 
@@ -75,11 +78,22 @@ func TestLoad_MoreMode(t *testing.T) {
 	}
 }
 
+func TestLoad_MermaidTheme(t *testing.T) {
+	setupTestConfig(t, `{"mermaid": {"theme": "dark"}}`)
+	cfg := Load()
+	if cfg.Mermaid.Theme != "dark" {
+		t.Errorf("theme = %q, want %q", cfg.Mermaid.Theme, "dark")
+	}
+}
+
 func TestLoad_EmptyConfig(t *testing.T) {
 	setupTestConfig(t, `{}`)
 	cfg := Load()
-	if cfg.Pager.Mode != "more" {
-		t.Errorf("mode = %q, want %q", cfg.Pager.Mode, "more")
+	if cfg.Pager.Mode != "less" {
+		t.Errorf("mode = %q, want %q", cfg.Pager.Mode, "less")
+	}
+	if cfg.Mermaid.Theme != "auto" {
+		t.Errorf("theme = %q, want %q", cfg.Mermaid.Theme, "auto")
 	}
 }
 
@@ -103,7 +117,7 @@ func TestLoad_ConfigPathError(t *testing.T) {
 	t.Cleanup(func() { configPathFunc = origFunc })
 
 	cfg := Load()
-	if cfg.Pager.Mode != "more" {
-		t.Errorf("mode = %q, want %q", cfg.Pager.Mode, "more")
+	if cfg.Pager.Mode != "less" {
+		t.Errorf("mode = %q, want %q", cfg.Pager.Mode, "less")
 	}
 }

--- a/internal/mermaid/html.go
+++ b/internal/mermaid/html.go
@@ -42,10 +42,12 @@ func resolveTheme(name string) (theme, background string) {
 }
 
 // IsKnownTheme reports whether name is a recognized Mermaid theme (so callers
-// can warn on a typo rather than silently falling back to the default).
+// can warn on a typo rather than silently falling back to the default). "auto"
+// means "detect from the terminal background" and is resolved by the caller
+// before reaching resolveTheme.
 func IsKnownTheme(name string) bool {
 	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "", "light", "default", "dark", "forest", "neutral", "base":
+	case "", "auto", "light", "default", "dark", "forest", "neutral", "base":
 		return true
 	default:
 		return false

--- a/internal/mermaid/html.go
+++ b/internal/mermaid/html.go
@@ -14,14 +14,50 @@ import (
 //go:embed mermaid.min.js
 var mermaidJS string
 
-const (
-	pdfCSS = "body{font-family:Arial,Helvetica,sans-serif;padding:24px;background:#fff;} .mermaid{margin:24px 0;}"
-	pngCSS = "body{font-family:Arial,Helvetica,sans-serif;padding:24px;background:#fff;width:100%;} .mermaid{margin:24px 0;width:100%;} svg{width:100%;height:auto;font-size:20px;} svg text{font-size:20px !important;} .label{font-size:20px !important;}"
-)
+func pdfCSS(bg string) string {
+	return "body{font-family:Arial,Helvetica,sans-serif;padding:24px;background:" + bg + ";} .mermaid{margin:24px 0;}"
+}
+
+func pngCSS(bg string) string {
+	return "body{font-family:Arial,Helvetica,sans-serif;padding:24px;background:" + bg + ";width:100%;} .mermaid{margin:24px 0;width:100%;} svg{width:100%;height:auto;font-size:20px;} svg text{font-size:20px !important;} .label{font-size:20px !important;}"
+}
+
+// resolveTheme maps a user-supplied theme name to a canonical Mermaid theme and
+// a matching page background. Unknown names fall back to the default theme. The
+// returned theme is always one of a fixed set of safe literals, so it is safe to
+// interpolate into the init script.
+func resolveTheme(name string) (theme, background string) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "dark":
+		return "dark", "#1e1e1e"
+	case "forest":
+		return "forest", "#ffffff"
+	case "neutral":
+		return "neutral", "#ffffff"
+	case "base":
+		return "base", "#ffffff"
+	default: // "", "light", "default", or anything unrecognized
+		return "default", "#ffffff"
+	}
+}
+
+// IsKnownTheme reports whether name is a recognized Mermaid theme (so callers
+// can warn on a typo rather than silently falling back to the default).
+func IsKnownTheme(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "", "light", "default", "dark", "forest", "neutral", "base":
+		return true
+	default:
+		return false
+	}
+}
 
 type htmlConfig struct {
 	AssignIDs bool
 	CSS       string
+	// Theme is a canonical Mermaid theme name (from resolveTheme); safe to
+	// interpolate into the init script.
+	Theme string
 }
 
 func buildMermaidHTML(diagrams []string, cfg htmlConfig) (string, []string) {
@@ -52,17 +88,20 @@ func buildMermaidHTML(diagrams []string, cfg htmlConfig) (string, []string) {
 	b.WriteString(mermaidJS)
 	b.WriteString("\n</script>\n")
 	fmt.Fprintf(&b, "<script nonce=\"%s\">\n", nonce)
-	b.WriteString(mermaidInitScript())
+	b.WriteString(mermaidInitScript(cfg.Theme))
 	b.WriteString("</script>\n")
 	b.WriteString("</body></html>")
 
 	return b.String(), ids
 }
 
-func mermaidInitScript() string {
+func mermaidInitScript(theme string) string {
+	if theme == "" {
+		theme = "default"
+	}
 	return "window.__MERMAID_DONE__ = false; window.__MERMAID_ERROR__ = '';\n" +
 		"(async function(){\n" +
-		"try { mermaid.initialize({ startOnLoad: false, securityLevel: 'strict' }); await mermaid.run({ querySelector: '.mermaid' }); window.__MERMAID_DONE__ = true; }\n" +
+		"try { mermaid.initialize({ startOnLoad: false, securityLevel: 'strict', theme: '" + theme + "' }); await mermaid.run({ querySelector: '.mermaid' }); window.__MERMAID_DONE__ = true; }\n" +
 		"catch(e){ window.__MERMAID_ERROR__ = (e && e.message) ? e.message : String(e); }\n" +
 		"})();\n"
 }

--- a/internal/mermaid/pdf.go
+++ b/internal/mermaid/pdf.go
@@ -16,12 +16,13 @@ const (
 	paperHeightIn = 11.69
 )
 
-func RenderPDF(diagrams []string) ([]byte, error) {
+func RenderPDF(diagrams []string, theme string) ([]byte, error) {
 	if len(diagrams) == 0 {
 		return nil, errors.New("no mermaid blocks found")
 	}
 
-	htmlDoc, _ := buildMermaidHTML(diagrams, htmlConfig{CSS: pdfCSS})
+	themeName, bg := resolveTheme(theme)
+	htmlDoc, _ := buildMermaidHTML(diagrams, htmlConfig{CSS: pdfCSS(bg), Theme: themeName})
 	pageURL, cleanup, err := serveHTML(htmlDoc)
 	if err != nil {
 		return nil, err

--- a/internal/mermaid/pdf_test.go
+++ b/internal/mermaid/pdf_test.go
@@ -15,7 +15,7 @@ func TestRenderPDF(t *testing.T) {
 		t.Skip("chrome/chromium not available")
 	}
 
-	pdf, err := RenderPDF([]string{"flowchart TD\n  A-->B"})
+	pdf, err := RenderPDF([]string{"flowchart TD\n  A-->B"}, "")
 	if err != nil {
 		t.Fatalf("render failed: %v", err)
 	}
@@ -32,7 +32,7 @@ func TestRenderPDF_MultipleDiagrams(t *testing.T) {
 		t.Skip("chrome/chromium not available")
 	}
 
-	pdf, err := RenderPDF([]string{"flowchart TD\n  A-->B", "flowchart TD\n  C-->D"})
+	pdf, err := RenderPDF([]string{"flowchart TD\n  A-->B", "flowchart TD\n  C-->D"}, "")
 	if err != nil {
 		t.Fatalf("render failed: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestRenderPDF_MultipleDiagrams(t *testing.T) {
 }
 
 func TestRenderPDF_EmptyDiagrams(t *testing.T) {
-	_, err := RenderPDF(nil)
+	_, err := RenderPDF(nil, "")
 	if err == nil {
 		t.Fatal("expected error for empty diagrams")
 	}

--- a/internal/mermaid/png.go
+++ b/internal/mermaid/png.go
@@ -10,12 +10,13 @@ import (
 	"github.com/chromedp/chromedp"
 )
 
-func RenderPNGs(diagrams []string, widthCells int) ([][]byte, error) {
+func RenderPNGs(diagrams []string, widthCells int, theme string) ([][]byte, error) {
 	if len(diagrams) == 0 {
 		return nil, errors.New("no mermaid blocks found")
 	}
 
-	htmlDoc, ids := buildMermaidHTML(diagrams, htmlConfig{AssignIDs: true, CSS: pngCSS})
+	themeName, bg := resolveTheme(theme)
+	htmlDoc, ids := buildMermaidHTML(diagrams, htmlConfig{AssignIDs: true, CSS: pngCSS(bg), Theme: themeName})
 	pageURL, cleanup, err := serveHTML(htmlDoc)
 	if err != nil {
 		return nil, err

--- a/internal/mermaid/png_test.go
+++ b/internal/mermaid/png_test.go
@@ -33,7 +33,7 @@ func TestViewportWidth_Normal(t *testing.T) {
 
 func TestBuildMermaidHTML_WithIDs(t *testing.T) {
 	diagrams := []string{"A-->B", "C-->D"}
-	html, ids := buildMermaidHTML(diagrams, htmlConfig{AssignIDs: true, CSS: pngCSS})
+	html, ids := buildMermaidHTML(diagrams, htmlConfig{AssignIDs: true, CSS: pngCSS("#ffffff")})
 
 	if len(ids) != 2 {
 		t.Fatalf("expected 2 IDs, got %d", len(ids))
@@ -69,7 +69,7 @@ func TestBuildMermaidHTML_WithIDs(t *testing.T) {
 
 func TestBuildMermaidHTML_PDF(t *testing.T) {
 	diagrams := []string{"X-->Y"}
-	html, ids := buildMermaidHTML(diagrams, htmlConfig{CSS: pdfCSS})
+	html, ids := buildMermaidHTML(diagrams, htmlConfig{CSS: pdfCSS("#ffffff")})
 
 	if len(ids) != 0 {
 		t.Fatalf("expected 0 IDs for PDF mode, got %d", len(ids))
@@ -89,7 +89,7 @@ func TestBuildMermaidHTML_PDF(t *testing.T) {
 }
 
 func TestRenderPNGs_EmptyDiagrams(t *testing.T) {
-	_, err := RenderPNGs(nil, 80)
+	_, err := RenderPNGs(nil, 80, "")
 	if err == nil {
 		t.Fatal("expected error for empty diagrams")
 	}
@@ -106,7 +106,7 @@ func TestRenderPNGs(t *testing.T) {
 		t.Skip("chrome/chromium not available")
 	}
 
-	pngs, err := RenderPNGs([]string{"flowchart TD\n  A-->B"}, 80)
+	pngs, err := RenderPNGs([]string{"flowchart TD\n  A-->B"}, 80, "")
 	if err != nil {
 		t.Fatalf("render failed: %v", err)
 	}

--- a/internal/mermaid/theme_test.go
+++ b/internal/mermaid/theme_test.go
@@ -1,0 +1,54 @@
+package mermaid
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveTheme(t *testing.T) {
+	cases := []struct {
+		in        string
+		wantTheme string
+		wantBG    string
+	}{
+		{"", "default", "#ffffff"},
+		{"light", "default", "#ffffff"},
+		{"default", "default", "#ffffff"},
+		{"dark", "dark", "#1e1e1e"},
+		{"DARK", "dark", "#1e1e1e"},
+		{" forest ", "forest", "#ffffff"},
+		{"neutral", "neutral", "#ffffff"},
+		{"base", "base", "#ffffff"},
+		{"bogus", "default", "#ffffff"},
+	}
+	for _, c := range cases {
+		gotTheme, gotBG := resolveTheme(c.in)
+		if gotTheme != c.wantTheme || gotBG != c.wantBG {
+			t.Errorf("resolveTheme(%q) = (%q,%q), want (%q,%q)", c.in, gotTheme, gotBG, c.wantTheme, c.wantBG)
+		}
+	}
+}
+
+func TestIsKnownTheme(t *testing.T) {
+	for _, ok := range []string{"", "light", "default", "dark", "forest", "neutral", "base", "DARK"} {
+		if !IsKnownTheme(ok) {
+			t.Errorf("IsKnownTheme(%q) = false, want true", ok)
+		}
+	}
+	for _, bad := range []string{"bogus", "midnight", "solarized"} {
+		if IsKnownTheme(bad) {
+			t.Errorf("IsKnownTheme(%q) = true, want false", bad)
+		}
+	}
+}
+
+func TestBuildMermaidHTML_ThemeAndBackground(t *testing.T) {
+	themeName, bg := resolveTheme("dark")
+	html, _ := buildMermaidHTML([]string{"A-->B"}, htmlConfig{CSS: pngCSS(bg), Theme: themeName})
+	if !strings.Contains(html, "theme: 'dark'") {
+		t.Errorf("html missing dark theme in init script")
+	}
+	if !strings.Contains(html, "background:#1e1e1e") {
+		t.Errorf("html missing dark background")
+	}
+}

--- a/internal/pager/less.go
+++ b/internal/pager/less.go
@@ -1,0 +1,383 @@
+package pager
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// less.go implements a less-like pager that scrolls a viewport (rather than
+// moving a cursor as vim mode does) while preserving inline terminal images.
+//
+// Image safety: like more mode, it never re-flows or width-trims a line. Each
+// display line is reprinted verbatim, and image lines carry a glowm-rows height
+// (parsed by splitDisplayLines) so paging math reserves the right number of
+// terminal rows and never splits an image across a screen boundary. Navigation
+// repaints the screen, which re-emits the image escapes intact.
+
+// keyType values local to less mode (half-page motions). Offset well past the
+// shared keyType constants defined in vim.go to avoid collisions.
+const (
+	keyHalfDown keyType = iota + 1000
+	keyHalfUp
+)
+
+func pageLess(output string) error {
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		return printOutput(output)
+	}
+
+	height := terminalHeight()
+	if height <= 0 {
+		return printOutput(output)
+	}
+
+	lines, heights := splitDisplayLines(output)
+
+	// Precompute search text and image flags per line. Image lines (height > 1,
+	// or carrying a raw image escape) are never searched or highlighted, since
+	// injecting reverse-video into image payload bytes would corrupt them.
+	plain := make([]string, len(lines))
+	isImage := make([]bool, len(lines))
+	for i, line := range lines {
+		if heights[i] > 1 || strings.Contains(line, "\x1bP") || strings.Contains(line, "\x1b]1337") {
+			isImage[i] = true
+			continue
+		}
+		plain[i] = stripANSI(line)
+	}
+
+	reader, shouldClose := openTTYReader()
+	if shouldClose {
+		defer reader.Close()
+	}
+
+	oldState, err := term.MakeRaw(int(reader.Fd()))
+	if err != nil {
+		return printOutput(output)
+	}
+	defer term.Restore(int(reader.Fd()), oldState)
+	defer setupSignalHandler(int(reader.Fd()), oldState, func() {
+		fmt.Fprint(os.Stdout, ansiAltScreenOff)
+	})()
+
+	bufReader := bufio.NewReader(reader)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	// Alternate screen buffer preserves the shell's scrollback.
+	fmt.Fprint(writer, ansiAltScreenOn)
+	defer fmt.Fprint(os.Stdout, ansiAltScreenOff)
+
+	p := &lessState{
+		lines:   lines,
+		heights: heights,
+		plain:   plain,
+		isImage: isImage,
+		height:  height,
+	}
+
+	p.redraw(writer)
+	for {
+		k := readLessKey(bufReader, writer, p)
+		if p.handleKey(k) {
+			break
+		}
+		p.redraw(writer)
+	}
+	return nil
+}
+
+type lessState struct {
+	lines      []string
+	heights    []int
+	plain      []string
+	isImage    []bool
+	height     int
+	top        int // index of the logical line at the top of the viewport
+	lastSearch string
+	lastDir    searchDir
+	status     string
+}
+
+func (p *lessState) linesPerPage() int {
+	n := p.height - 1 // reserve the bottom row for the status line
+	if n <= 0 {
+		return 1
+	}
+	return n
+}
+
+// h returns the display-row height of line i (clamped to at least 1).
+func (p *lessState) h(i int) int {
+	if i < 0 || i >= len(p.heights) {
+		return 1
+	}
+	if p.heights[i] < 1 {
+		return 1
+	}
+	return p.heights[i]
+}
+
+func (p *lessState) redraw(w *bufio.Writer) {
+	fmt.Fprint(w, ansiClearScreen)
+	end := pageEnd(p.heights, p.top, p.linesPerPage())
+	for i := p.top; i < end; i++ {
+		line := p.lines[i]
+		if p.lastSearch != "" && !p.isImage[i] {
+			line = highlightLine(line, p.plain[i], p.lastSearch)
+		}
+		fmt.Fprint(w, "\r")
+		fmt.Fprint(w, line)
+		fmt.Fprint(w, "\r\n")
+	}
+	p.drawStatus(w, end)
+	w.Flush()
+}
+
+func (p *lessState) drawStatus(w *bufio.Writer, end int) {
+	width := terminalWidth()
+	if width <= 0 {
+		width = 80
+	}
+	total := len(p.lines)
+	status := p.status
+	if status == "" {
+		percent := 100
+		if total > 0 {
+			percent = end * 100 / total
+		}
+		if percent > 100 {
+			percent = 100
+		}
+		first := p.top + 1
+		if total == 0 {
+			first = 0
+		}
+		status = fmt.Sprintf(
+			"glowm  %d/%d (%d%%)  (q quit, j/k line, space/b page, d/u half, g/G top/bottom, / ? search, n/N)",
+			first, total, percent,
+		)
+	}
+	fmt.Fprintf(w, "\033[%d;1H", p.height)
+	fmt.Fprint(w, ansiReverseVideo)
+	fmt.Fprint(w, trimPlainToWidth(status, width))
+	fmt.Fprint(w, ansiReset)
+	fmt.Fprint(w, "\r"+ansiClearToEOL)
+}
+
+func (p *lessState) handleKey(k key) bool {
+	lpp := p.linesPerPage()
+	switch k.typ {
+	case keyQuit:
+		return true
+	case keyPageDown:
+		p.top = pageEnd(p.heights, p.top, lpp)
+	case keyPageUp:
+		p.top = p.retreat(p.top, lpp)
+	case keyHalfDown:
+		p.top = p.advance(p.top, lpp/2)
+	case keyHalfUp:
+		p.top = p.retreat(p.top, lpp/2)
+	case keyDown:
+		p.top++
+	case keyUp:
+		p.top--
+	case keyTop:
+		p.top = 0
+	case keyBottom:
+		p.top = p.maxTop()
+	case keySearch:
+		p.lastSearch = k.text
+		p.lastDir = dirForward
+		p.search(dirForward)
+	case keySearchBackward:
+		p.lastSearch = k.text
+		p.lastDir = dirBackward
+		p.search(dirBackward)
+	case keySearchNext:
+		p.search(p.lastDir)
+	case keySearchPrev:
+		p.search(p.lastDir.reverse())
+	}
+	p.clampTop()
+	return false
+}
+
+// advance moves the top index forward until at least `rows` display rows have
+// been passed, returning the new top.
+func (p *lessState) advance(from, rows int) int {
+	if rows < 1 {
+		rows = 1
+	}
+	used := 0
+	i := from
+	for i < len(p.lines) && used < rows {
+		used += p.h(i)
+		i++
+	}
+	return i
+}
+
+// retreat moves the top index backward until at least `rows` display rows have
+// been passed, returning the new top.
+func (p *lessState) retreat(from, rows int) int {
+	if rows < 1 {
+		rows = 1
+	}
+	used := 0
+	i := from
+	for i > 0 && used < rows {
+		i--
+		used += p.h(i)
+	}
+	return i
+}
+
+// maxTop returns the largest top index that still fills the final page, so that
+// scrolling stops with the last line resting at the bottom of the viewport.
+func (p *lessState) maxTop() int {
+	lpp := p.linesPerPage()
+	used := 0
+	i := len(p.lines)
+	for i > 0 {
+		h := p.h(i - 1)
+		if used+h > lpp && used > 0 {
+			break
+		}
+		used += h
+		i--
+	}
+	if i >= len(p.lines) {
+		i = len(p.lines) - 1
+	}
+	if i < 0 {
+		i = 0
+	}
+	return i
+}
+
+func (p *lessState) clampTop() {
+	if p.top < 0 {
+		p.top = 0
+	}
+	if mt := p.maxTop(); p.top > mt {
+		p.top = mt
+	}
+}
+
+// search scans for lastSearch starting just past the current top, in the given
+// direction, wrapping around. Image lines are skipped. On a hit, the matching
+// line is moved to the top of the viewport.
+func (p *lessState) search(dir searchDir) {
+	if p.lastSearch == "" || len(p.lines) == 0 {
+		p.status = "no previous search"
+		return
+	}
+	n := len(p.lines)
+	step := 1
+	if dir == dirBackward {
+		step = -1
+	}
+	for i := 1; i <= n; i++ {
+		idx := ((p.top+i*step)%n + n) % n
+		if !p.isImage[idx] && p.plain[idx] != "" && strings.Contains(p.plain[idx], p.lastSearch) {
+			p.top = idx
+			p.status = ""
+			return
+		}
+	}
+	p.status = "pattern not found: " + p.lastSearch
+}
+
+func readLessKey(r *bufio.Reader, w *bufio.Writer, p *lessState) key {
+	b, err := r.ReadByte()
+	if err != nil {
+		return key{typ: keyQuit}
+	}
+	switch b {
+	case 'q', 'Q':
+		return key{typ: keyQuit}
+	case ' ', 'f', 0x06: // space, f, ctrl-f
+		return key{typ: keyPageDown}
+	case 'b', 0x02: // b, ctrl-b
+		return key{typ: keyPageUp}
+	case 'd', 0x04: // d, ctrl-d
+		return key{typ: keyHalfDown}
+	case 'u', 0x15: // u, ctrl-u
+		return key{typ: keyHalfUp}
+	case 'j', '\n', '\r', 'e':
+		return key{typ: keyDown}
+	case 'k', 'y':
+		return key{typ: keyUp}
+	case 'g', '<':
+		return key{typ: keyTop}
+	case 'G', '>':
+		return key{typ: keyBottom}
+	case 'n':
+		return key{typ: keySearchNext}
+	case 'N':
+		return key{typ: keySearchPrev}
+	case '/':
+		text := readLessSearch(r, w, p, "/")
+		if text == "" {
+			return key{typ: keyUnknown}
+		}
+		return key{typ: keySearch, text: text}
+	case '?':
+		text := readLessSearch(r, w, p, "?")
+		if text == "" {
+			return key{typ: keyUnknown}
+		}
+		return key{typ: keySearchBackward, text: text}
+	case 0x1b:
+		return readEscapeKey(r) // arrow keys -> up/down/page up/page down
+	}
+	return key{typ: keyUnknown}
+}
+
+// readLessSearch reads a search pattern at the bottom prompt until Enter, or
+// returns "" if cancelled with Esc.
+func readLessSearch(r *bufio.Reader, w *bufio.Writer, p *lessState, prefix string) string {
+	width := terminalWidth()
+	if width <= 0 {
+		width = 80
+	}
+	var buf []byte
+	p.status = prefix
+	p.drawStatus(w, pageEnd(p.heights, p.top, p.linesPerPage()))
+	w.Flush()
+	for {
+		b, err := r.ReadByte()
+		if err != nil {
+			p.status = ""
+			return ""
+		}
+		switch b {
+		case '\n', '\r':
+			p.status = ""
+			return string(buf)
+		case 0x7f, 0x08: // backspace / DEL
+			if len(buf) > 0 {
+				buf = buf[:len(buf)-1]
+			}
+			p.status = prefix + string(buf)
+		case 0x1b: // Esc cancels; swallow a trailing arrow-key sequence if present.
+			if next, _ := r.ReadByte(); next == '[' {
+				_, _ = r.ReadByte()
+			}
+			p.status = ""
+			return ""
+		default:
+			if b >= 0x20 {
+				buf = append(buf, b)
+				p.status = prefix + string(buf)
+			}
+		}
+		p.drawStatus(w, pageEnd(p.heights, p.top, p.linesPerPage()))
+		w.Flush()
+	}
+}

--- a/internal/pager/less.go
+++ b/internal/pager/less.go
@@ -3,6 +3,7 @@ package pager
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -35,21 +36,6 @@ func pageLess(output string) error {
 		return printOutput(output)
 	}
 
-	lines, heights := splitDisplayLines(output)
-
-	// Precompute search text and image flags per line. Image lines (height > 1,
-	// or carrying a raw image escape) are never searched or highlighted, since
-	// injecting reverse-video into image payload bytes would corrupt them.
-	plain := make([]string, len(lines))
-	isImage := make([]bool, len(lines))
-	for i, line := range lines {
-		if heights[i] > 1 || strings.Contains(line, "\x1bP") || strings.Contains(line, "\x1b]1337") {
-			isImage[i] = true
-			continue
-		}
-		plain[i] = stripANSI(line)
-	}
-
 	reader, shouldClose := openTTYReader()
 	if shouldClose {
 		defer reader.Close()
@@ -72,13 +58,7 @@ func pageLess(output string) error {
 	fmt.Fprint(writer, ansiAltScreenOn)
 	defer fmt.Fprint(os.Stdout, ansiAltScreenOff)
 
-	p := &lessState{
-		lines:   lines,
-		heights: heights,
-		plain:   plain,
-		isImage: isImage,
-		height:  height,
-	}
+	p := newLessState(output, height)
 
 	p.redraw(writer)
 	prev := p.viewKey()
@@ -116,6 +96,42 @@ type lessState struct {
 	lastSearch string
 	lastDir    searchDir
 	status     string
+}
+
+// newLessState builds a text-mode less pager from rendered output. Image lines
+// (height > 1, or carrying a raw image escape) are flagged so they are never
+// searched or highlighted, since injecting reverse-video into image payload
+// bytes would corrupt them.
+func newLessState(output string, height int) *lessState {
+	lines, heights := splitDisplayLines(output)
+	plain := make([]string, len(lines))
+	isImage := make([]bool, len(lines))
+	for i, line := range lines {
+		if heights[i] > 1 || strings.Contains(line, "\x1bP") || strings.Contains(line, "\x1b]1337") {
+			isImage[i] = true
+			continue
+		}
+		plain[i] = stripANSI(line)
+	}
+	return &lessState{
+		lines:   lines,
+		heights: heights,
+		plain:   plain,
+		isImage: isImage,
+		height:  height,
+	}
+}
+
+// applyContent rebuilds the pager from freshly rendered output (used by watch
+// mode), preserving the current scroll position.
+func (p *lessState) applyContent(c Content) {
+	np := newLessState(c.Output, p.height)
+	p.lines = np.lines
+	p.heights = np.heights
+	p.plain = np.plain
+	p.isImage = np.isImage
+	p.status = ""
+	p.clampTop()
 }
 
 func (p *lessState) linesPerPage() int {
@@ -310,7 +326,7 @@ func (p *lessState) search(dir searchDir) {
 	p.status = "pattern not found: " + p.lastSearch
 }
 
-func readLessKey(r *bufio.Reader, w *bufio.Writer, p *lessState) key {
+func readLessKey(r io.ByteReader, w *bufio.Writer, p *lessState) key {
 	b, err := r.ReadByte()
 	if err != nil {
 		return key{typ: keyQuit}
@@ -358,7 +374,7 @@ func readLessKey(r *bufio.Reader, w *bufio.Writer, p *lessState) key {
 
 // readLessSearch reads a search pattern at the bottom prompt until Enter, or
 // returns "" if cancelled with Esc.
-func readLessSearch(r *bufio.Reader, w *bufio.Writer, p *lessState, prefix string) string {
+func readLessSearch(r io.ByteReader, w *bufio.Writer, p *lessState, prefix string) string {
 	width := terminalWidth()
 	if width <= 0 {
 		width = 80

--- a/internal/pager/less.go
+++ b/internal/pager/less.go
@@ -81,14 +81,29 @@ func pageLess(output string) error {
 	}
 
 	p.redraw(writer)
+	prev := p.viewKey()
 	for {
-		k := readLessKey(bufReader, writer, p)
-		if p.handleKey(k) {
+		quit := p.handleKey(readLessKey(bufReader, writer, p))
+		// Coalesce already-arrived input (fast key-repeat / mouse wheel) into a
+		// single repaint.
+		for !quit && bufReader.Buffered() > 0 {
+			quit = p.handleKey(readLessKey(bufReader, writer, p))
+		}
+		if quit {
 			break
 		}
-		p.redraw(writer)
+		if cur := p.viewKey(); cur != prev {
+			p.redraw(writer)
+			prev = cur
+		}
 	}
 	return nil
+}
+
+// viewKey returns a value that changes whenever the visible frame would change,
+// so the render loop can skip no-op repaints.
+func (p *lessState) viewKey() string {
+	return fmt.Sprintf("%d|%s|%s", p.top, p.lastSearch, p.status)
 }
 
 type lessState struct {
@@ -123,6 +138,7 @@ func (p *lessState) h(i int) int {
 }
 
 func (p *lessState) redraw(w *bufio.Writer) {
+	fmt.Fprint(w, syncBegin)
 	fmt.Fprint(w, ansiClearScreen)
 	end := pageEnd(p.heights, p.top, p.linesPerPage())
 	for i := p.top; i < end; i++ {
@@ -135,6 +151,7 @@ func (p *lessState) redraw(w *bufio.Writer) {
 		fmt.Fprint(w, "\r\n")
 	}
 	p.drawStatus(w, end)
+	fmt.Fprint(w, syncEnd)
 	w.Flush()
 }
 

--- a/internal/pager/less_kitty.go
+++ b/internal/pager/less_kitty.go
@@ -1,0 +1,390 @@
+package pager
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+
+	"github.com/atani/glowm/internal/termimage"
+)
+
+// less_kitty.go implements the less pager for terminals that speak the Kitty
+// graphics protocol (Kitty, Ghostty). Unlike the atomic pageLess/pageMore paths,
+// it tracks scroll position in display *rows* rather than logical lines, so an
+// image can scroll partially off the top or bottom edge: each redraw emits a
+// vertically-cropped Kitty placement (EncodeKittyCrop) for only the visible
+// slice of each image. This removes the "blank gap then the whole image pops
+// into frame" behavior of the atomic pagers.
+
+// kittyDeleteAll removes all transmitted images and placements. Emitted at the
+// start of every redraw (and on exit) so re-transmitting cropped slices each
+// frame does not leak image memory in the terminal.
+const kittyDeleteAll = "\x1b_Ga=d,d=A\x1b\\"
+
+// PageLessKitty pages output (which still contains the raw marker lines, not
+// baked-in image escapes) in less mode with smooth image scrolling. images is
+// indexed by marker order; widthCells is the render width used to size images.
+func PageLessKitty(output string, markers []string, images [][]byte, widthCells int) error {
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		// Not a terminal: fall back to a plain dump with full images inlined.
+		return printOutput(termimage.ReplaceMarkersWithImages(output, markers, images, termimage.FormatKitty, widthCells))
+	}
+	height := terminalHeight()
+	if height <= 0 {
+		return printOutput(termimage.ReplaceMarkersWithImages(output, markers, images, termimage.FormatKitty, widthCells))
+	}
+
+	reader, shouldClose := openTTYReader()
+	if shouldClose {
+		defer reader.Close()
+	}
+
+	oldState, err := term.MakeRaw(int(reader.Fd()))
+	if err != nil {
+		return printOutput(termimage.ReplaceMarkersWithImages(output, markers, images, termimage.FormatKitty, widthCells))
+	}
+	defer term.Restore(int(reader.Fd()), oldState)
+	defer setupSignalHandler(int(reader.Fd()), oldState, func() {
+		fmt.Fprint(os.Stdout, kittyDeleteAll+ansiAltScreenOff)
+	})()
+
+	bufReader := bufio.NewReader(reader)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	fmt.Fprint(writer, ansiAltScreenOn)
+	defer fmt.Fprint(os.Stdout, kittyDeleteAll+ansiAltScreenOff)
+
+	p := newLessKittyState(output, markers, images, widthCells, height)
+	p.redraw(writer)
+	for {
+		k := readKittyKey(bufReader, writer, p)
+		if p.handleKey(k) {
+			break
+		}
+		p.redraw(writer)
+	}
+	return nil
+}
+
+// lessSeg is one logical line: either a text line (rows == 1) or an image
+// occupying rows terminal rows.
+type lessSeg struct {
+	isImage bool
+	text    string // rendered text (with ANSI), for text segments
+	plain   string // ANSI-stripped text, for search/highlight
+	imgIdx  int    // index into images, for image segments
+	rows    int    // display-row height
+}
+
+type lessKittyState struct {
+	segs       []lessSeg
+	images     [][]byte
+	widthCells int
+	rowStart   []int // flat display-row index at which each segment begins
+	totalRows  int
+	height     int
+	rowTop     int // top of the viewport, in display rows
+	lastSearch string
+	lastDir    searchDir
+	status     string
+}
+
+func newLessKittyState(output string, markers []string, images [][]byte, widthCells, height int) *lessKittyState {
+	// Match the marker-replacement convention in termimage: a line is an image
+	// if its ANSI-stripped, space-trimmed text equals a marker string.
+	markerIdx := make(map[string]int, len(markers))
+	for i, m := range markers {
+		markerIdx[m] = i
+	}
+
+	rawLines := strings.Split(output, "\n")
+	segs := make([]lessSeg, 0, len(rawLines))
+	for _, line := range rawLines {
+		trimmed := strings.TrimSpace(stripANSI(line))
+		if idx, ok := markerIdx[trimmed]; ok && idx < len(images) {
+			rows := termimage.ImageRows(images[idx], widthCells)
+			if rows < 1 {
+				rows = 1
+			}
+			segs = append(segs, lessSeg{isImage: true, imgIdx: idx, rows: rows})
+			continue
+		}
+		segs = append(segs, lessSeg{text: line, plain: trimmed, rows: 1})
+	}
+
+	rowStart := make([]int, len(segs))
+	total := 0
+	for i := range segs {
+		rowStart[i] = total
+		total += segs[i].rows
+	}
+
+	return &lessKittyState{
+		segs:       segs,
+		images:     images,
+		widthCells: widthCells,
+		rowStart:   rowStart,
+		totalRows:  total,
+		height:     height,
+	}
+}
+
+func (p *lessKittyState) linesPerPage() int {
+	n := p.height - 1 // reserve the bottom row for the status line
+	if n <= 0 {
+		return 1
+	}
+	return n
+}
+
+func (p *lessKittyState) maxRowTop() int {
+	m := p.totalRows - p.linesPerPage()
+	if m < 0 {
+		return 0
+	}
+	return m
+}
+
+func (p *lessKittyState) clampTop() {
+	if p.rowTop < 0 {
+		p.rowTop = 0
+	}
+	if m := p.maxRowTop(); p.rowTop > m {
+		p.rowTop = m
+	}
+}
+
+// segAt returns the segment index containing display row `row`, and the row
+// offset within that segment.
+func (p *lessKittyState) segAt(row int) (int, int) {
+	for i := range p.segs {
+		if row < p.rowStart[i]+p.segs[i].rows {
+			return i, row - p.rowStart[i]
+		}
+	}
+	if len(p.segs) == 0 {
+		return 0, 0
+	}
+	last := len(p.segs) - 1
+	return last, p.segs[last].rows - 1
+}
+
+func (p *lessKittyState) redraw(w *bufio.Writer) {
+	fmt.Fprint(w, kittyDeleteAll)
+	fmt.Fprint(w, ansiClearScreen)
+
+	remaining := p.linesPerPage()
+	screenRow := 1
+	si, off := p.segAt(p.rowTop)
+	for si < len(p.segs) && remaining > 0 {
+		seg := p.segs[si]
+		fmt.Fprintf(w, "\033[%d;1H", screenRow)
+		if seg.isImage {
+			show := seg.rows - off
+			if show > remaining {
+				show = remaining
+			}
+			fmt.Fprint(w, termimage.EncodeKittyCrop(p.images[seg.imgIdx], p.widthCells, seg.rows, off, show))
+			screenRow += show
+			remaining -= show
+		} else {
+			line := seg.text
+			if p.lastSearch != "" {
+				line = highlightLine(line, seg.plain, p.lastSearch)
+			}
+			fmt.Fprint(w, line)
+			screenRow++
+			remaining--
+		}
+		si++
+		off = 0
+	}
+	p.drawStatus(w)
+	w.Flush()
+}
+
+func (p *lessKittyState) drawStatus(w *bufio.Writer) {
+	width := terminalWidth()
+	if width <= 0 {
+		width = 80
+	}
+	status := p.status
+	if status == "" {
+		bottom := p.rowTop + p.linesPerPage()
+		if bottom > p.totalRows {
+			bottom = p.totalRows
+		}
+		percent := 100
+		if p.totalRows > 0 {
+			percent = bottom * 100 / p.totalRows
+		}
+		if percent > 100 {
+			percent = 100
+		}
+		first := p.rowTop + 1
+		if p.totalRows == 0 {
+			first = 0
+		}
+		status = fmt.Sprintf(
+			"glowm  %d/%d (%d%%)  (q quit, j/k line, space/b page, d/u half, g/G top/bottom, / ? search, n/N)",
+			first, p.totalRows, percent,
+		)
+	}
+	fmt.Fprintf(w, "\033[%d;1H", p.height)
+	fmt.Fprint(w, ansiReverseVideo)
+	fmt.Fprint(w, trimPlainToWidth(status, width))
+	fmt.Fprint(w, ansiReset)
+	fmt.Fprint(w, "\r"+ansiClearToEOL)
+}
+
+func (p *lessKittyState) handleKey(k key) bool {
+	lpp := p.linesPerPage()
+	switch k.typ {
+	case keyQuit:
+		return true
+	case keyDown:
+		p.rowTop++
+	case keyUp:
+		p.rowTop--
+	case keyPageDown:
+		p.rowTop += lpp
+	case keyPageUp:
+		p.rowTop -= lpp
+	case keyHalfDown:
+		p.rowTop += lpp / 2
+	case keyHalfUp:
+		p.rowTop -= lpp / 2
+	case keyTop:
+		p.rowTop = 0
+	case keyBottom:
+		p.rowTop = p.maxRowTop()
+	case keySearch:
+		p.lastSearch = k.text
+		p.lastDir = dirForward
+		p.search(dirForward)
+	case keySearchBackward:
+		p.lastSearch = k.text
+		p.lastDir = dirBackward
+		p.search(dirBackward)
+	case keySearchNext:
+		p.search(p.lastDir)
+	case keySearchPrev:
+		p.search(p.lastDir.reverse())
+	}
+	p.clampTop()
+	return false
+}
+
+// search scans text segments for lastSearch in the given direction starting just
+// past the segment currently at the top, wrapping around. On a hit, that
+// segment's first row becomes the top of the viewport. Image segments are
+// skipped.
+func (p *lessKittyState) search(dir searchDir) {
+	if p.lastSearch == "" || len(p.segs) == 0 {
+		p.status = "no previous search"
+		return
+	}
+	cur, _ := p.segAt(p.rowTop)
+	n := len(p.segs)
+	step := 1
+	if dir == dirBackward {
+		step = -1
+	}
+	for i := 1; i <= n; i++ {
+		idx := ((cur+i*step)%n + n) % n
+		s := p.segs[idx]
+		if !s.isImage && s.plain != "" && strings.Contains(s.plain, p.lastSearch) {
+			p.rowTop = p.rowStart[idx]
+			p.status = ""
+			return
+		}
+	}
+	p.status = "pattern not found: " + p.lastSearch
+}
+
+func readKittyKey(r *bufio.Reader, w *bufio.Writer, p *lessKittyState) key {
+	b, err := r.ReadByte()
+	if err != nil {
+		return key{typ: keyQuit}
+	}
+	switch b {
+	case 'q', 'Q':
+		return key{typ: keyQuit}
+	case ' ', 'f', 0x06: // space, f, ctrl-f
+		return key{typ: keyPageDown}
+	case 'b', 0x02: // b, ctrl-b
+		return key{typ: keyPageUp}
+	case 'd', 0x04: // d, ctrl-d
+		return key{typ: keyHalfDown}
+	case 'u', 0x15: // u, ctrl-u
+		return key{typ: keyHalfUp}
+	case 'j', '\n', '\r', 'e':
+		return key{typ: keyDown}
+	case 'k', 'y':
+		return key{typ: keyUp}
+	case 'g', '<':
+		return key{typ: keyTop}
+	case 'G', '>':
+		return key{typ: keyBottom}
+	case 'n':
+		return key{typ: keySearchNext}
+	case 'N':
+		return key{typ: keySearchPrev}
+	case '/':
+		text := readKittySearch(r, w, p, "/")
+		if text == "" {
+			return key{typ: keyUnknown}
+		}
+		return key{typ: keySearch, text: text}
+	case '?':
+		text := readKittySearch(r, w, p, "?")
+		if text == "" {
+			return key{typ: keyUnknown}
+		}
+		return key{typ: keySearchBackward, text: text}
+	case 0x1b:
+		return readEscapeKey(r) // arrow keys
+	}
+	return key{typ: keyUnknown}
+}
+
+func readKittySearch(r *bufio.Reader, w *bufio.Writer, p *lessKittyState, prefix string) string {
+	var buf []byte
+	p.status = prefix
+	p.drawStatus(w)
+	w.Flush()
+	for {
+		b, err := r.ReadByte()
+		if err != nil {
+			p.status = ""
+			return ""
+		}
+		switch b {
+		case '\n', '\r':
+			p.status = ""
+			return string(buf)
+		case 0x7f, 0x08: // backspace / DEL
+			if len(buf) > 0 {
+				buf = buf[:len(buf)-1]
+			}
+			p.status = prefix + string(buf)
+		case 0x1b: // Esc cancels; swallow a trailing arrow-key sequence if present.
+			if next, _ := r.ReadByte(); next == '[' {
+				_, _ = r.ReadByte()
+			}
+			p.status = ""
+			return ""
+		default:
+			if b >= 0x20 {
+				buf = append(buf, b)
+				p.status = prefix + string(buf)
+			}
+		}
+		p.drawStatus(w)
+		w.Flush()
+	}
+}

--- a/internal/pager/less_kitty.go
+++ b/internal/pager/less_kitty.go
@@ -24,6 +24,15 @@ import (
 // frame does not leak image memory in the terminal.
 const kittyDeleteAll = "\x1b_Ga=d,d=A\x1b\\"
 
+// Synchronized output (DEC mode 2026): the terminal buffers everything between
+// begin and end and presents it as a single atomic frame, so a clear-then-
+// repaint is never shown half-finished. Ghostty and Kitty support it; on
+// terminals that don't, these are ignored. This is the main flicker fix.
+const (
+	syncBegin = "\x1b[?2026h"
+	syncEnd   = "\x1b[?2026l"
+)
+
 // PageLessKitty pages output (which still contains the raw marker lines, not
 // baked-in image escapes) in less mode with smooth image scrolling. images is
 // indexed by marker order; widthCells is the render width used to size images.
@@ -60,14 +69,31 @@ func PageLessKitty(output string, markers []string, images [][]byte, widthCells 
 
 	p := newLessKittyState(output, markers, images, widthCells, height)
 	p.redraw(writer)
+	prev := p.viewKey()
 	for {
-		k := readKittyKey(bufReader, writer, p)
-		if p.handleKey(k) {
+		quit := p.handleKey(readKittyKey(bufReader, writer, p))
+		// Coalesce input that already arrived (fast key-repeat / mouse wheel)
+		// into a single repaint instead of one repaint per event.
+		for !quit && bufReader.Buffered() > 0 {
+			quit = p.handleKey(readKittyKey(bufReader, writer, p))
+		}
+		if quit {
 			break
 		}
-		p.redraw(writer)
+		// Skip the repaint entirely if nothing visible changed (e.g. scrolling
+		// past the top/bottom edge).
+		if cur := p.viewKey(); cur != prev {
+			p.redraw(writer)
+			prev = cur
+		}
 	}
 	return nil
+}
+
+// viewKey returns a value that changes whenever the visible frame would change,
+// so the render loop can skip no-op repaints.
+func (p *lessKittyState) viewKey() string {
+	return fmt.Sprintf("%d|%s|%s", p.rowTop, p.lastSearch, p.status)
 }
 
 // lessSeg is one logical line: either a text line (rows == 1) or an image
@@ -174,6 +200,7 @@ func (p *lessKittyState) segAt(row int) (int, int) {
 }
 
 func (p *lessKittyState) redraw(w *bufio.Writer) {
+	fmt.Fprint(w, syncBegin)
 	fmt.Fprint(w, kittyDeleteAll)
 	fmt.Fprint(w, ansiClearScreen)
 
@@ -204,6 +231,7 @@ func (p *lessKittyState) redraw(w *bufio.Writer) {
 		off = 0
 	}
 	p.drawStatus(w)
+	fmt.Fprint(w, syncEnd)
 	w.Flush()
 }
 

--- a/internal/pager/less_kitty.go
+++ b/internal/pager/less_kitty.go
@@ -3,6 +3,7 @@ package pager
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -157,6 +158,19 @@ func newLessKittyState(output string, markers []string, images [][]byte, widthCe
 		totalRows:  total,
 		height:     height,
 	}
+}
+
+// applyContent rebuilds the pager from freshly rendered content (used by watch
+// mode), preserving the current scroll position and active search.
+func (p *lessKittyState) applyContent(c Content) {
+	np := newLessKittyState(c.Output, c.Markers, c.Images, c.WidthCells, p.height)
+	p.segs = np.segs
+	p.images = np.images
+	p.widthCells = np.widthCells
+	p.rowStart = np.rowStart
+	p.totalRows = np.totalRows
+	p.status = ""
+	p.clampTop()
 }
 
 func (p *lessKittyState) linesPerPage() int {
@@ -334,7 +348,7 @@ func (p *lessKittyState) search(dir searchDir) {
 	p.status = "pattern not found: " + p.lastSearch
 }
 
-func readKittyKey(r *bufio.Reader, w *bufio.Writer, p *lessKittyState) key {
+func readKittyKey(r io.ByteReader, w *bufio.Writer, p *lessKittyState) key {
 	b, err := r.ReadByte()
 	if err != nil {
 		return key{typ: keyQuit}
@@ -380,7 +394,7 @@ func readKittyKey(r *bufio.Reader, w *bufio.Writer, p *lessKittyState) key {
 	return key{typ: keyUnknown}
 }
 
-func readKittySearch(r *bufio.Reader, w *bufio.Writer, p *lessKittyState, prefix string) string {
+func readKittySearch(r io.ByteReader, w *bufio.Writer, p *lessKittyState, prefix string) string {
 	var buf []byte
 	p.status = prefix
 	p.drawStatus(w)

--- a/internal/pager/less_kitty_test.go
+++ b/internal/pager/less_kitty_test.go
@@ -1,0 +1,153 @@
+package pager
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"testing"
+)
+
+func makeKittyTestPNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: 10, G: 120, B: 200, A: 255})
+		}
+	}
+	var b bytes.Buffer
+	if err := png.Encode(&b, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	return b.Bytes()
+}
+
+// newKittyStateManual builds a lessKittyState directly from segment heights,
+// bypassing PNG decoding, so scroll math can be tested in isolation.
+func newKittyStateManual(visibleRows int, segs []lessSeg) *lessKittyState {
+	rowStart := make([]int, len(segs))
+	total := 0
+	for i := range segs {
+		if segs[i].rows < 1 {
+			segs[i].rows = 1
+		}
+		rowStart[i] = total
+		total += segs[i].rows
+	}
+	return &lessKittyState{
+		segs:      segs,
+		rowStart:  rowStart,
+		totalRows: total,
+		height:    visibleRows + 1, // +1 for the status row
+	}
+}
+
+func TestKittySegAt(t *testing.T) {
+	// text(1), image(5), text(1) => rows: [0],[1..5],[6]
+	p := newKittyStateManual(3, []lessSeg{
+		{plain: "a", rows: 1},
+		{isImage: true, rows: 5},
+		{plain: "b", rows: 1},
+	})
+	cases := []struct {
+		row, wantSeg, wantOff int
+	}{
+		{0, 0, 0},
+		{1, 1, 0}, // top of image
+		{3, 1, 2}, // 2 rows into image
+		{5, 1, 4}, // last row of image
+		{6, 2, 0}, // text after image
+	}
+	for _, c := range cases {
+		gotSeg, gotOff := p.segAt(c.row)
+		if gotSeg != c.wantSeg || gotOff != c.wantOff {
+			t.Errorf("segAt(%d) = (%d,%d), want (%d,%d)", c.row, gotSeg, gotOff, c.wantSeg, c.wantOff)
+		}
+	}
+}
+
+func TestKittyRowScroll(t *testing.T) {
+	// Smooth scroll must step one row at a time, even into a tall image.
+	p := newKittyStateManual(4, []lessSeg{
+		{plain: "a", rows: 1},
+		{isImage: true, rows: 6}, // rows 1..6
+		{plain: "b", rows: 1},    // row 7
+	}) // totalRows = 8, lpp = 4, maxRowTop = 4
+
+	for want := 1; want <= 4; want++ {
+		p.handleKey(key{typ: keyDown})
+		if p.rowTop != want {
+			t.Fatalf("after %d downs: rowTop=%d, want %d", want, p.rowTop, want)
+		}
+	}
+	// Clamped at maxRowTop = 8 - 4 = 4.
+	p.handleKey(key{typ: keyDown})
+	if p.rowTop != 4 {
+		t.Fatalf("rowTop should clamp to maxRowTop 4, got %d", p.rowTop)
+	}
+	p.handleKey(key{typ: keyTop})
+	if p.rowTop != 0 {
+		t.Fatalf("keyTop: rowTop=%d, want 0", p.rowTop)
+	}
+	p.handleKey(key{typ: keyBottom})
+	if p.rowTop != 4 {
+		t.Fatalf("keyBottom: rowTop=%d, want 4", p.rowTop)
+	}
+}
+
+func TestKittyHalfAndFullPage(t *testing.T) {
+	segs := make([]lessSeg, 20)
+	for i := range segs {
+		segs[i] = lessSeg{plain: "x", rows: 1}
+	}
+	p := newKittyStateManual(4, segs) // lpp=4, totalRows=20, maxRowTop=16
+
+	p.handleKey(key{typ: keyPageDown})
+	if p.rowTop != 4 {
+		t.Fatalf("page down: rowTop=%d, want 4", p.rowTop)
+	}
+	p.handleKey(key{typ: keyHalfDown}) // +2
+	if p.rowTop != 6 {
+		t.Fatalf("half down: rowTop=%d, want 6", p.rowTop)
+	}
+	p.handleKey(key{typ: keyHalfUp}) // -2
+	if p.rowTop != 4 {
+		t.Fatalf("half up: rowTop=%d, want 4", p.rowTop)
+	}
+}
+
+func TestKittySearchJumpsToSegmentRow(t *testing.T) {
+	// Trailing padding keeps the match out of the final page so it can sit at
+	// the top of the viewport without being clamped to maxRowTop.
+	p := newKittyStateManual(2, []lessSeg{
+		{plain: "intro", rows: 1},  // row 0
+		{isImage: true, rows: 4},   // rows 1..4
+		{plain: "target", rows: 1}, // row 5
+		{plain: "p1", rows: 1},     // row 6
+		{plain: "p2", rows: 1},     // row 7
+	})
+	p.handleKey(key{typ: keySearch, text: "target"})
+	if p.rowTop != 5 {
+		t.Fatalf("search jumped to rowTop=%d, want 5 (segment start row)", p.rowTop)
+	}
+}
+
+func TestKittyNewStateParsesMarkers(t *testing.T) {
+	// A 100x40 PNG at width 10 => imageRows = ceil((40/100)*10/2) = 2 rows.
+	img := makeKittyTestPNG(t, 100, 40)
+	markers := []string{"@@IMG0@@"}
+	images := [][]byte{img}
+	output := "line one\n@@IMG0@@\nline three"
+
+	p := newLessKittyState(output, markers, images, 10, 5)
+	if len(p.segs) != 3 {
+		t.Fatalf("segs=%d, want 3", len(p.segs))
+	}
+	if !p.segs[1].isImage || p.segs[1].rows != 2 {
+		t.Fatalf("segs[1]=%+v, want image with 2 rows", p.segs[1])
+	}
+	if p.totalRows != 4 { // 1 + 2 + 1
+		t.Fatalf("totalRows=%d, want 4", p.totalRows)
+	}
+}

--- a/internal/pager/less_test.go
+++ b/internal/pager/less_test.go
@@ -1,0 +1,131 @@
+package pager
+
+import "testing"
+
+// newLessState builds a less-mode state from plain text lines (each 1 row tall)
+// with a viewport tall enough for `visible` content rows.
+func newLessState(visible int, lines []string) *lessState {
+	heights := make([]int, len(lines))
+	plain := make([]string, len(lines))
+	isImage := make([]bool, len(lines))
+	for i, l := range lines {
+		heights[i] = 1
+		plain[i] = l
+	}
+	return &lessState{
+		lines:   lines,
+		heights: heights,
+		plain:   plain,
+		isImage: isImage,
+		height:  visible + 1, // +1 for the status row
+	}
+}
+
+func TestLessLineScroll(t *testing.T) {
+	lines := []string{"a", "b", "c", "d", "e", "f"}
+	p := newLessState(3, lines) // shows 3 lines per page
+
+	p.handleKey(key{typ: keyDown})
+	if p.top != 1 {
+		t.Fatalf("keyDown: top=%d, want 1", p.top)
+	}
+	p.handleKey(key{typ: keyDown})
+	p.handleKey(key{typ: keyUp})
+	if p.top != 1 {
+		t.Fatalf("down,down,up: top=%d, want 1", p.top)
+	}
+	// Cannot scroll above the first line.
+	p.handleKey(key{typ: keyUp})
+	p.handleKey(key{typ: keyUp})
+	if p.top != 0 {
+		t.Fatalf("clamped top: top=%d, want 0", p.top)
+	}
+}
+
+func TestLessPageAndHalfPage(t *testing.T) {
+	lines := []string{"l0", "l1", "l2", "l3", "l4", "l5", "l6", "l7", "l8", "l9"}
+	p := newLessState(4, lines) // 4 rows per page
+
+	p.handleKey(key{typ: keyPageDown})
+	if p.top != 4 {
+		t.Fatalf("page down: top=%d, want 4", p.top)
+	}
+	p.handleKey(key{typ: keyHalfUp}) // half of 4 = 2
+	if p.top != 2 {
+		t.Fatalf("half up: top=%d, want 2", p.top)
+	}
+	p.handleKey(key{typ: keyHalfDown})
+	if p.top != 4 {
+		t.Fatalf("half down: top=%d, want 4", p.top)
+	}
+}
+
+func TestLessTopBottomClamp(t *testing.T) {
+	lines := []string{"l0", "l1", "l2", "l3", "l4", "l5"}
+	p := newLessState(3, lines) // 3 rows per page; last page starts at index 3
+
+	p.handleKey(key{typ: keyBottom})
+	if p.top != 3 {
+		t.Fatalf("bottom: top=%d, want 3 (last page)", p.top)
+	}
+	// Paging/scrolling past the end must not exceed maxTop.
+	p.handleKey(key{typ: keyPageDown})
+	if p.top != 3 {
+		t.Fatalf("page down past end: top=%d, want 3", p.top)
+	}
+	p.handleKey(key{typ: keyTop})
+	if p.top != 0 {
+		t.Fatalf("top: top=%d, want 0", p.top)
+	}
+}
+
+func TestLessImageHeightAware(t *testing.T) {
+	// Line 1 is an image occupying 5 rows; the rest are 1-row text lines.
+	lines := []string{"text0", "IMG", "text2", "text3", "text4"}
+	p := newLessState(6, lines) // 6 rows per page
+	p.heights[1] = 5
+	p.isImage[1] = true
+
+	// maxTop must account for the tall image: from the end, rows are
+	// text4,text3,text2(=3) then IMG(=5) would exceed 6, so the last page
+	// starts at index 2.
+	if got := p.maxTop(); got != 2 {
+		t.Fatalf("maxTop with tall image: got %d, want 2", got)
+	}
+}
+
+func TestLessSearch(t *testing.T) {
+	// Trailing padding ensures the second match is not in the final page, so it
+	// can rest at the top of the viewport without being clamped to maxTop.
+	lines := []string{"alpha", "beta", "gamma", "delta", "beta again", "p1", "p2", "p3"}
+	p := newLessState(2, lines)
+
+	p.handleKey(key{typ: keySearch, text: "beta"})
+	if p.top != 1 {
+		t.Fatalf("search 'beta': top=%d, want 1", p.top)
+	}
+	p.handleKey(key{typ: keySearchNext})
+	if p.top != 4 {
+		t.Fatalf("search next 'beta': top=%d, want 4", p.top)
+	}
+	// Backward from the match wraps to the earlier occurrence.
+	p.handleKey(key{typ: keySearchPrev})
+	if p.top != 1 {
+		t.Fatalf("search prev 'beta': top=%d, want 1", p.top)
+	}
+}
+
+func TestLessSearchSkipsImages(t *testing.T) {
+	lines := []string{"intro", "PAYLOAD", "match here"}
+	p := newLessState(2, lines)
+	// Mark line 1 as an image whose raw payload happens to contain the pattern;
+	// search must not match or highlight it.
+	p.isImage[1] = true
+	p.plain[1] = ""
+	p.heights[1] = 3
+
+	p.handleKey(key{typ: keySearch, text: "match"})
+	if p.top != 2 {
+		t.Fatalf("search must skip image line: top=%d, want 2", p.top)
+	}
+}

--- a/internal/pager/less_test.go
+++ b/internal/pager/less_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 // newLessState builds a less-mode state from plain text lines (each 1 row tall)
 // with a viewport tall enough for `visible` content rows.
-func newLessState(visible int, lines []string) *lessState {
+func newLessTestState(visible int, lines []string) *lessState {
 	heights := make([]int, len(lines))
 	plain := make([]string, len(lines))
 	isImage := make([]bool, len(lines))
@@ -23,7 +23,7 @@ func newLessState(visible int, lines []string) *lessState {
 
 func TestLessLineScroll(t *testing.T) {
 	lines := []string{"a", "b", "c", "d", "e", "f"}
-	p := newLessState(3, lines) // shows 3 lines per page
+	p := newLessTestState(3, lines) // shows 3 lines per page
 
 	p.handleKey(key{typ: keyDown})
 	if p.top != 1 {
@@ -44,7 +44,7 @@ func TestLessLineScroll(t *testing.T) {
 
 func TestLessPageAndHalfPage(t *testing.T) {
 	lines := []string{"l0", "l1", "l2", "l3", "l4", "l5", "l6", "l7", "l8", "l9"}
-	p := newLessState(4, lines) // 4 rows per page
+	p := newLessTestState(4, lines) // 4 rows per page
 
 	p.handleKey(key{typ: keyPageDown})
 	if p.top != 4 {
@@ -62,7 +62,7 @@ func TestLessPageAndHalfPage(t *testing.T) {
 
 func TestLessTopBottomClamp(t *testing.T) {
 	lines := []string{"l0", "l1", "l2", "l3", "l4", "l5"}
-	p := newLessState(3, lines) // 3 rows per page; last page starts at index 3
+	p := newLessTestState(3, lines) // 3 rows per page; last page starts at index 3
 
 	p.handleKey(key{typ: keyBottom})
 	if p.top != 3 {
@@ -82,7 +82,7 @@ func TestLessTopBottomClamp(t *testing.T) {
 func TestLessImageHeightAware(t *testing.T) {
 	// Line 1 is an image occupying 5 rows; the rest are 1-row text lines.
 	lines := []string{"text0", "IMG", "text2", "text3", "text4"}
-	p := newLessState(6, lines) // 6 rows per page
+	p := newLessTestState(6, lines) // 6 rows per page
 	p.heights[1] = 5
 	p.isImage[1] = true
 
@@ -98,7 +98,7 @@ func TestLessSearch(t *testing.T) {
 	// Trailing padding ensures the second match is not in the final page, so it
 	// can rest at the top of the viewport without being clamped to maxTop.
 	lines := []string{"alpha", "beta", "gamma", "delta", "beta again", "p1", "p2", "p3"}
-	p := newLessState(2, lines)
+	p := newLessTestState(2, lines)
 
 	p.handleKey(key{typ: keySearch, text: "beta"})
 	if p.top != 1 {
@@ -117,7 +117,7 @@ func TestLessSearch(t *testing.T) {
 
 func TestLessSearchSkipsImages(t *testing.T) {
 	lines := []string{"intro", "PAYLOAD", "match here"}
-	p := newLessState(2, lines)
+	p := newLessTestState(2, lines)
 	// Mark line 1 as an image whose raw payload happens to contain the pattern;
 	// search must not match or highlight it.
 	p.isImage[1] = true

--- a/internal/pager/pager.go
+++ b/internal/pager/pager.go
@@ -15,12 +15,13 @@ type Mode string
 const (
 	ModeMore Mode = "more"
 	ModeVim  Mode = "vim"
+	ModeLess Mode = "less"
 )
 
 // ValidMode returns true if the given mode is recognized.
 func ValidMode(m Mode) bool {
 	switch m {
-	case ModeMore, ModeVim:
+	case ModeMore, ModeVim, ModeLess:
 		return true
 	default:
 		return false
@@ -32,6 +33,8 @@ func PageWithMode(output string, mode Mode) error {
 	switch mode {
 	case ModeVim:
 		return pageVim(output)
+	case ModeLess:
+		return pageLess(output)
 	default:
 		return pageMore(output)
 	}

--- a/internal/pager/vim.go
+++ b/internal/pager/vim.go
@@ -3,6 +3,7 @@ package pager
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -237,7 +238,7 @@ func (p *pagerState) search(dir searchDir) {
 
 	// Search from cursor+step in the given direction
 	for i := 1; i < n; i++ {
-		idx := ((p.cursor + i*step) % n + n) % n
+		idx := ((p.cursor+i*step)%n + n) % n
 		if strings.Contains(p.plain[idx], p.lastSearch) {
 			p.cursor = idx
 			p.status = ""
@@ -425,7 +426,7 @@ func readKey(r *bufio.Reader, w *bufio.Writer, p *pagerState) key {
 	return key{typ: keyUnknown}
 }
 
-func readEscapeKey(r *bufio.Reader) key {
+func readEscapeKey(r io.ByteReader) key {
 	seq, _ := r.ReadByte()
 	if seq != '[' {
 		return key{typ: keyUnknown}

--- a/internal/pager/watch_pager.go
+++ b/internal/pager/watch_pager.go
@@ -1,0 +1,200 @@
+package pager
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/term"
+
+	"github.com/atani/glowm/internal/termimage"
+)
+
+// watch_pager.go drives the less pagers in watch mode: an event loop that waits
+// on both keystrokes and a reload signal, so the view can refresh in place when
+// the source file changes. The non-watch pagers (pageLess/pageLessKitty) keep
+// their simple blocking loops; this code is additive.
+
+// Content is a freshly rendered document handed to a watch-mode pager. For the
+// Kitty path, Output still contains the raw marker lines and Images/Markers are
+// populated; for the text path, Output is the final rendered text and the image
+// fields are empty.
+type Content struct {
+	Output     string
+	Markers    []string
+	Images     [][]byte
+	WidthCells int
+}
+
+// RenderFunc produces the current Content (e.g. by re-reading and re-rendering
+// the source file). It is called once per reload signal.
+type RenderFunc func() (Content, error)
+
+// chanReader adapts a byte channel to io.ByteReader, with a one-byte pushback so
+// the event loop can peek the first byte of a key (via select) and still hand a
+// complete reader to the key parser.
+type chanReader struct {
+	ch          <-chan byte
+	pending     byte
+	havePending bool
+}
+
+func (c *chanReader) ReadByte() (byte, error) {
+	if c.havePending {
+		c.havePending = false
+		return c.pending, nil
+	}
+	b, ok := <-c.ch
+	if !ok {
+		return 0, io.EOF
+	}
+	return b, nil
+}
+
+// runReload is the shared event loop. A goroutine pumps raw terminal bytes into
+// byteCh; the loop selects between a reload signal and the next keystroke. While
+// parsing a single key (which may read several bytes, e.g. an escape sequence or
+// a search prompt) it reads straight from byteCh, so a reload only interrupts
+// between keys. All terminal writes happen here on the main goroutine.
+func runReload(
+	bufReader *bufio.Reader,
+	reload <-chan struct{},
+	render RenderFunc,
+	parseAndHandle func(r io.ByteReader) (quit bool),
+	apply func(Content),
+	setStatus func(string),
+	redraw func(),
+	viewKey func() string,
+) {
+	byteCh := make(chan byte, 1024)
+	done := make(chan struct{})
+	go func() {
+		for {
+			b, err := bufReader.ReadByte()
+			if err != nil {
+				close(byteCh)
+				return
+			}
+			select {
+			case byteCh <- b:
+			case <-done:
+				return
+			}
+		}
+	}()
+	defer close(done)
+
+	redraw()
+	prev := viewKey()
+	for {
+		select {
+		case <-reload:
+			c, err := render()
+			if err != nil {
+				setStatus("reload failed: " + err.Error())
+			} else {
+				apply(c)
+			}
+			redraw()
+			prev = viewKey()
+		case b, ok := <-byteCh:
+			if !ok {
+				return
+			}
+			r := &chanReader{ch: byteCh, pending: b, havePending: true}
+			quit := parseAndHandle(r)
+			// Coalesce input that already arrived into a single repaint.
+			for !quit && len(byteCh) > 0 {
+				quit = parseAndHandle(r)
+			}
+			if quit {
+				return
+			}
+			if cur := viewKey(); cur != prev {
+				redraw()
+				prev = cur
+			}
+		}
+	}
+}
+
+// PageLessKittyWatch runs the smooth Kitty pager in watch mode.
+func PageLessKittyWatch(initial Content, reload <-chan struct{}, render RenderFunc) error {
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		return printOutput(termimage.ReplaceMarkersWithImages(initial.Output, initial.Markers, initial.Images, termimage.FormatKitty, initial.WidthCells))
+	}
+	height := terminalHeight()
+	if height <= 0 {
+		return printOutput(termimage.ReplaceMarkersWithImages(initial.Output, initial.Markers, initial.Images, termimage.FormatKitty, initial.WidthCells))
+	}
+
+	reader, shouldClose := openTTYReader()
+	if shouldClose {
+		defer reader.Close()
+	}
+	oldState, err := term.MakeRaw(int(reader.Fd()))
+	if err != nil {
+		return printOutput(termimage.ReplaceMarkersWithImages(initial.Output, initial.Markers, initial.Images, termimage.FormatKitty, initial.WidthCells))
+	}
+	defer term.Restore(int(reader.Fd()), oldState)
+	defer setupSignalHandler(int(reader.Fd()), oldState, func() {
+		fmt.Fprint(os.Stdout, kittyDeleteAll+ansiAltScreenOff)
+	})()
+
+	bufReader := bufio.NewReader(reader)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	fmt.Fprint(writer, ansiAltScreenOn)
+	defer fmt.Fprint(os.Stdout, kittyDeleteAll+ansiAltScreenOff)
+
+	p := newLessKittyState(initial.Output, initial.Markers, initial.Images, initial.WidthCells, height)
+	runReload(bufReader, reload, render,
+		func(r io.ByteReader) bool { return p.handleKey(readKittyKey(r, writer, p)) },
+		func(c Content) { p.applyContent(c) },
+		func(s string) { p.status = s },
+		func() { p.redraw(writer) },
+		p.viewKey,
+	)
+	return nil
+}
+
+// PageLessWatch runs the text-mode less pager in watch mode.
+func PageLessWatch(initial Content, reload <-chan struct{}, render RenderFunc) error {
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		return printOutput(initial.Output)
+	}
+	height := terminalHeight()
+	if height <= 0 {
+		return printOutput(initial.Output)
+	}
+
+	reader, shouldClose := openTTYReader()
+	if shouldClose {
+		defer reader.Close()
+	}
+	oldState, err := term.MakeRaw(int(reader.Fd()))
+	if err != nil {
+		return printOutput(initial.Output)
+	}
+	defer term.Restore(int(reader.Fd()), oldState)
+	defer setupSignalHandler(int(reader.Fd()), oldState, func() {
+		fmt.Fprint(os.Stdout, ansiAltScreenOff)
+	})()
+
+	bufReader := bufio.NewReader(reader)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	fmt.Fprint(writer, ansiAltScreenOn)
+	defer fmt.Fprint(os.Stdout, ansiAltScreenOff)
+
+	p := newLessState(initial.Output, height)
+	runReload(bufReader, reload, render,
+		func(r io.ByteReader) bool { return p.handleKey(readLessKey(r, writer, p)) },
+		func(c Content) { p.applyContent(c) },
+		func(s string) { p.status = s },
+		func() { p.redraw(writer) },
+		p.viewKey,
+	)
+	return nil
+}

--- a/internal/pager/watch_pager_test.go
+++ b/internal/pager/watch_pager_test.go
@@ -1,0 +1,93 @@
+package pager
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLessApplyContentPreservesScroll(t *testing.T) {
+	lines := make([]string, 30)
+	for i := range lines {
+		lines[i] = "old line"
+	}
+	p := newLessState(strings.Join(lines, "\n"), 6) // lpp = 5
+	p.top = 10
+
+	newLines := make([]string, 40)
+	for i := range newLines {
+		newLines[i] = "new line"
+	}
+	p.applyContent(Content{Output: strings.Join(newLines, "\n")})
+
+	if p.top != 10 {
+		t.Errorf("top after reload = %d, want 10 (preserved)", p.top)
+	}
+	if len(p.lines) != 40 {
+		t.Errorf("lines after reload = %d, want 40", len(p.lines))
+	}
+	if p.status != "" {
+		t.Errorf("status after reload = %q, want empty", p.status)
+	}
+}
+
+func TestLessApplyContentClampsScrollWhenShorter(t *testing.T) {
+	long := make([]string, 30)
+	for i := range long {
+		long[i] = "x"
+	}
+	p := newLessState(strings.Join(long, "\n"), 6) // lpp = 5
+	p.top = 25
+
+	// New content is much shorter; top must clamp to the new maxTop.
+	p.applyContent(Content{Output: "a\nb\nc"})
+	if p.top > p.maxTop() {
+		t.Errorf("top=%d exceeds maxTop=%d after shrinking", p.top, p.maxTop())
+	}
+}
+
+func TestKittyApplyContentRebuildsSegments(t *testing.T) {
+	img := makeKittyTestPNG(t, 100, 40) // 2 rows at width 10
+	markers := []string{"@@IMG0@@"}
+	images := [][]byte{img}
+
+	// Start with a text-only document.
+	p := newLessKittyState("a\nb\nc\nd", nil, nil, 10, 5)
+	if p.totalRows != 4 {
+		t.Fatalf("initial totalRows=%d, want 4", p.totalRows)
+	}
+	p.rowTop = 2
+
+	// Reload with a document that now contains a diagram.
+	p.applyContent(Content{Output: "intro\n@@IMG0@@\noutro", Markers: markers, Images: images, WidthCells: 10})
+	if len(p.segs) != 3 {
+		t.Fatalf("segs after reload = %d, want 3", len(p.segs))
+	}
+	if !p.segs[1].isImage || p.segs[1].rows != 2 {
+		t.Errorf("segs[1] = %+v, want image with 2 rows", p.segs[1])
+	}
+	if p.totalRows != 4 { // 1 + 2 + 1
+		t.Errorf("totalRows after reload = %d, want 4", p.totalRows)
+	}
+	if p.rowTop > p.maxRowTop() {
+		t.Errorf("rowTop=%d exceeds maxRowTop=%d", p.rowTop, p.maxRowTop())
+	}
+}
+
+func TestChanReaderPushback(t *testing.T) {
+	ch := make(chan byte, 3)
+	ch <- 'b'
+	ch <- 'c'
+	close(ch)
+	r := &chanReader{ch: ch, pending: 'a', havePending: true}
+	got := []byte{}
+	for {
+		b, err := r.ReadByte()
+		if err != nil {
+			break
+		}
+		got = append(got, b)
+	}
+	if string(got) != "abc" {
+		t.Errorf("chanReader yielded %q, want %q", got, "abc")
+	}
+}

--- a/internal/render/ansi.go
+++ b/internal/render/ansi.go
@@ -60,6 +60,19 @@ func ANSI(md string, opts RenderOptions) (string, error) {
 	return out, nil
 }
 
+// AutoStyle resolves the "auto" style to a concrete "dark" or "light" by
+// querying the terminal background. Callers that re-render repeatedly while
+// holding the terminal in raw mode (e.g. watch mode) must call this once up
+// front and pass the result, because the background query reads from the
+// terminal and would otherwise race the pager's input reader on each redraw,
+// flipping the theme.
+func AutoStyle() string {
+	if termenv.HasDarkBackground() {
+		return "dark"
+	}
+	return "light"
+}
+
 // styleConfig resolves a style name to a concrete StyleConfig. The returned
 // bool is true for built-in styles (the "auto"/dark/light variants and any
 // name in glamour's DefaultStyles, e.g. notty/ascii/dracula/pink/tokyo-night);

--- a/internal/termimage/kitty_crop_test.go
+++ b/internal/termimage/kitty_crop_test.go
@@ -1,0 +1,65 @@
+package termimage
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"strings"
+	"testing"
+)
+
+func makeTestPNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: 200, G: 100, B: 50, A: 255})
+		}
+	}
+	var b bytes.Buffer
+	if err := png.Encode(&b, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	return b.Bytes()
+}
+
+func TestImagePixelSize(t *testing.T) {
+	p := makeTestPNG(t, 100, 40)
+	w, h := ImagePixelSize(p)
+	if w != 100 || h != 40 {
+		t.Fatalf("ImagePixelSize = (%d,%d), want (100,40)", w, h)
+	}
+	if w, h := ImagePixelSize([]byte("not a png")); w != 0 || h != 0 {
+		t.Fatalf("ImagePixelSize(bad) = (%d,%d), want (0,0)", w, h)
+	}
+}
+
+func TestEncodeKittyCrop(t *testing.T) {
+	p := makeTestPNG(t, 100, 40)
+	// totalRows=4 over a 40px-tall image => 10px/row.
+	// skip 1 row, show 2 rows => source y=10, h=20.
+	got := EncodeKittyCrop(p, 10, 4, 1, 2)
+	for _, want := range []string{"\x1b_G", "y=10", "w=100", "h=20", "c=10", "r=2", "C=1", "a=T"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("crop escape missing %q\n got: %q", want, got[:min(len(got), 120)])
+		}
+	}
+}
+
+func TestEncodeKittyCropDegenerate(t *testing.T) {
+	p := makeTestPNG(t, 100, 40)
+	if s := EncodeKittyCrop(p, 10, 4, 0, 0); s != "" {
+		t.Errorf("showRows=0 should yield empty, got %q", s)
+	}
+	if s := EncodeKittyCrop(p, 10, 4, 4, 1); s != "" {
+		t.Errorf("skip beyond image should yield empty, got %q", s)
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/termimage/termimage.go
+++ b/internal/termimage/termimage.go
@@ -1,7 +1,11 @@
 package termimage
 
 import (
+	"bytes"
 	"encoding/base64"
+	"fmt"
+	"image"
+	_ "image/png"
 	"os"
 	"strconv"
 	"strings"
@@ -18,8 +22,8 @@ const (
 )
 
 var (
-	detectOnce   sync.Once
-	detectedFmt  Format
+	detectOnce  sync.Once
+	detectedFmt Format
 )
 
 // Detect determines the terminal's image-protocol support. The result is
@@ -107,6 +111,69 @@ func encodeIterm2(png []byte, widthCells int) string {
 }
 
 func encodeKitty(png []byte, widthCells int) string {
+	params := "f=100,a=T"
+	if widthCells > 0 {
+		params += ",c=" + strconv.Itoa(widthCells)
+	}
+	return kittyEmit(png, params)
+}
+
+// ImagePixelSize returns the pixel dimensions of a PNG, or (0, 0) if it cannot
+// be decoded.
+func ImagePixelSize(png []byte) (int, int) {
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(png))
+	if err != nil {
+		return 0, 0
+	}
+	return cfg.Width, cfg.Height
+}
+
+// ImageRows returns the number of terminal rows an image occupies when scaled to
+// widthCells columns.
+func ImageRows(png []byte, widthCells int) int {
+	return imageRows(png, widthCells)
+}
+
+// EncodeKittyCrop displays a vertical slice of a PNG via the Kitty graphics
+// protocol: the slice skips skipRows rows from the top of the (widthCells x
+// totalRows) full placement and shows showRows rows. C=1 keeps the cursor
+// stationary so the caller controls placement with absolute positioning. This
+// lets a pager scroll an image one row at a time instead of all-or-nothing.
+func EncodeKittyCrop(png []byte, widthCells, totalRows, skipRows, showRows int) string {
+	if showRows <= 0 || totalRows <= 0 {
+		return ""
+	}
+	wpx, hpx := ImagePixelSize(png)
+	if wpx <= 0 || hpx <= 0 {
+		return ""
+	}
+	if skipRows < 0 {
+		skipRows = 0
+	}
+	// Map the row range to source pixels, proportionally, preserving aspect.
+	y := skipRows * hpx / totalRows
+	h := showRows * hpx / totalRows
+	if y >= hpx {
+		return ""
+	}
+	if y+h > hpx {
+		h = hpx - y
+	}
+	if h <= 0 {
+		return ""
+	}
+	params := fmt.Sprintf("f=100,a=T,C=1,x=0,y=%d,w=%d,h=%d", y, wpx, h)
+	if widthCells > 0 {
+		params += ",c=" + strconv.Itoa(widthCells)
+	}
+	params += ",r=" + strconv.Itoa(showRows)
+	return kittyEmit(png, params)
+}
+
+// kittyEmit base64-encodes png and writes it as one or more Kitty graphics
+// escape sequences, placing firstParams on the first chunk and chunking the
+// payload at 4096 bytes (the protocol limit) with the m= continuation flag.
+func kittyEmit(png []byte, firstParams string) string {
 	b64 := base64.StdEncoding.EncodeToString(png)
 	const chunkSize = 4096
 	var b strings.Builder
@@ -120,17 +187,11 @@ func encodeKitty(png []byte, widthCells int) string {
 			more = "1"
 		}
 		if i == 0 {
-			// First chunk: include full control parameters.
-			b.WriteString("\x1b_Gf=100,a=T,")
-			if widthCells > 0 {
-				b.WriteString("c=")
-				b.WriteString(strconv.Itoa(widthCells))
-				b.WriteString(",")
-			}
-			b.WriteString("m=")
+			b.WriteString("\x1b_G")
+			b.WriteString(firstParams)
+			b.WriteString(",m=")
 			b.WriteString(more)
 		} else {
-			// Subsequent chunks: only continuation flag.
 			b.WriteString("\x1b_Gm=")
 			b.WriteString(more)
 		}

--- a/internal/terminal/background.go
+++ b/internal/terminal/background.go
@@ -1,0 +1,142 @@
+package terminal
+
+import (
+	"bytes"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/term"
+)
+
+const bgQueryTimeout = 200 * time.Millisecond
+
+var (
+	bgOnce sync.Once
+	bgDark bool
+	bgOK   bool
+)
+
+// BackgroundIsDark reports whether the terminal background is dark, querying it
+// once via OSC 11 ("report background color"). The second return value is false
+// if the background could not be determined (not a TTY, no response, or an
+// unparseable reply), in which case callers should fall back to a light default.
+// The result is cached for the process.
+func BackgroundIsDark() (dark, ok bool) {
+	bgOnce.Do(func() {
+		bgDark, bgOK = detectBackground()
+	})
+	return bgDark, bgOK
+}
+
+func detectBackground() (bool, bool) {
+	// Querying needs a writable terminal (to send the query) and a readable one
+	// (to receive the reply). Mirror the Sixel DA1 probe and use stdout/stdin.
+	if !term.IsTerminal(int(os.Stdout.Fd())) || !term.IsTerminal(int(os.Stdin.Fd())) {
+		return false, false
+	}
+
+	fd := int(os.Stdin.Fd())
+	oldState, err := term.MakeRaw(fd)
+	if err != nil {
+		return false, false
+	}
+	defer term.Restore(fd, oldState) //nolint:errcheck
+
+	// OSC 11 with a "?" asks the terminal to report its background color.
+	if _, err := os.Stdout.WriteString("\x1b]11;?\x07"); err != nil {
+		return false, false
+	}
+
+	resp, ok := readOSCResponse(bgQueryTimeout)
+	if !ok {
+		return false, false
+	}
+	r, g, b, ok := parseOSC11Color(string(resp))
+	if !ok {
+		return false, false
+	}
+	// Perceptual (Rec. 709) relative luminance; below 0.5 reads as a dark theme.
+	lum := 0.2126*r + 0.7152*g + 0.0722*b
+	return lum < 0.5, true
+}
+
+// readOSCResponse reads from stdin until an OSC terminator (BEL or ST) or the
+// timeout. Returns (nil, false) on timeout.
+func readOSCResponse(timeout time.Duration) ([]byte, bool) {
+	ch := make(chan []byte, 1)
+	go func() {
+		var buf []byte
+		tmp := make([]byte, 64)
+		for {
+			n, err := os.Stdin.Read(tmp)
+			if n > 0 {
+				buf = append(buf, tmp[:n]...)
+				// BEL terminator, or ST (ESC backslash).
+				if bytes.IndexByte(buf, 0x07) >= 0 || bytes.Contains(buf, []byte{0x1b, '\\'}) {
+					ch <- buf
+					return
+				}
+			}
+			if err != nil {
+				if len(buf) > 0 {
+					ch <- buf
+				} else {
+					ch <- nil
+				}
+				return
+			}
+		}
+	}()
+
+	select {
+	case resp := <-ch:
+		return resp, resp != nil
+	case <-time.After(timeout):
+		return nil, false
+	}
+}
+
+// parseOSC11Color parses an OSC 11 reply of the form
+// "...rgb:RRRR/GGGG/BBBB<terminator>" into red/green/blue fractions in [0,1].
+// Each component may be 1-4 hex digits; per X11 convention it is normalized by
+// the maximum value for its digit width (so "ff" and "ffff" both mean 1.0).
+func parseOSC11Color(resp string) (r, g, b float64, ok bool) {
+	i := strings.Index(resp, "rgb:")
+	if i < 0 {
+		return 0, 0, 0, false
+	}
+	s := resp[i+len("rgb:"):]
+	if j := strings.IndexAny(s, "\x07\x1b"); j >= 0 {
+		s = s[:j]
+	}
+	parts := strings.Split(s, "/")
+	if len(parts) < 3 {
+		return 0, 0, 0, false
+	}
+	conv := func(p string) (float64, bool) {
+		p = strings.TrimSpace(p)
+		if p == "" || len(p) > 8 {
+			return 0, false
+		}
+		v, err := strconv.ParseUint(p, 16, 64)
+		if err != nil {
+			return 0, false
+		}
+		max := float64(uint64(1)<<(4*uint(len(p))) - 1)
+		if max <= 0 {
+			return 0, false
+		}
+		return float64(v) / max, true
+	}
+	var okr, okg, okb bool
+	r, okr = conv(parts[0])
+	g, okg = conv(parts[1])
+	b, okb = conv(parts[2])
+	if !okr || !okg || !okb {
+		return 0, 0, 0, false
+	}
+	return r, g, b, true
+}

--- a/internal/terminal/background_test.go
+++ b/internal/terminal/background_test.go
@@ -1,0 +1,55 @@
+package terminal
+
+import (
+	"math"
+	"testing"
+)
+
+func TestParseOSC11Color(t *testing.T) {
+	cases := []struct {
+		name                string
+		resp                string
+		wantR, wantG, wantB float64
+		wantOK              bool
+	}{
+		{"black 16-bit BEL", "\x1b]11;rgb:0000/0000/0000\x07", 0, 0, 0, true},
+		{"white 16-bit BEL", "\x1b]11;rgb:ffff/ffff/ffff\x07", 1, 1, 1, true},
+		{"white 8-bit", "\x1b]11;rgb:ff/ff/ff\x07", 1, 1, 1, true},
+		{"mid gray", "\x1b]11;rgb:8080/8080/8080\x07", 0x8080 / 65535.0, 0x8080 / 65535.0, 0x8080 / 65535.0, true},
+		{"ST terminator", "\x1b]11;rgb:1234/5678/9abc\x1b\\", 0x1234 / 65535.0, 0x5678 / 65535.0, 0x9abc / 65535.0, true},
+		{"no rgb", "\x1b]11;garbage\x07", 0, 0, 0, false},
+		{"too few parts", "\x1b]11;rgb:ffff/ffff\x07", 0, 0, 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r, g, b, ok := parseOSC11Color(c.resp)
+			if ok != c.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, c.wantOK)
+			}
+			if !ok {
+				return
+			}
+			const eps = 1e-9
+			if math.Abs(r-c.wantR) > eps || math.Abs(g-c.wantG) > eps || math.Abs(b-c.wantB) > eps {
+				t.Errorf("got (%v,%v,%v), want (%v,%v,%v)", r, g, b, c.wantR, c.wantG, c.wantB)
+			}
+		})
+	}
+}
+
+// TestLuminanceThreshold documents the dark/light decision used by
+// detectBackground for representative backgrounds.
+func TestLuminanceThreshold(t *testing.T) {
+	lum := func(r, g, b float64) float64 { return 0.2126*r + 0.7152*g + 0.0722*b }
+	if lum(0, 0, 0) >= 0.5 {
+		t.Error("black should be dark")
+	}
+	if lum(1, 1, 1) < 0.5 {
+		t.Error("white should be light")
+	}
+	// A typical dark-terminal background (#1e1e1e).
+	v := 0x1e / 255.0
+	if lum(v, v, v) >= 0.5 {
+		t.Error("#1e1e1e should be dark")
+	}
+}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -1,0 +1,122 @@
+// Package watch detects changes to a file by polling its modification time and
+// size, debouncing rapid edits so consumers re-render only once the file has
+// settled.
+package watch
+
+import (
+	"os"
+	"time"
+)
+
+// DefaultPoll is how often the file is stat'd.
+const DefaultPoll = 250 * time.Millisecond
+
+// DefaultDebounce is how long the file must stop changing before a change is
+// reported, so a re-render does not run against a half-written file.
+const DefaultDebounce = 150 * time.Millisecond
+
+// sig is a cheap fingerprint of a file's state. A change in modification time,
+// size, or existence counts as a change.
+type sig struct {
+	mod    time.Time
+	size   int64
+	exists bool
+}
+
+func statSig(path string) sig {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return sig{exists: false}
+	}
+	return sig{mod: fi.ModTime(), size: fi.Size(), exists: true}
+}
+
+func (a sig) equal(b sig) bool {
+	return a.exists == b.exists && a.size == b.size && a.mod.Equal(b.mod)
+}
+
+// Watcher polls a path and sends on C after the file changes and then stays
+// stable for the debounce window. C is buffered (size 1): if a consumer is busy,
+// repeated changes coalesce into a single pending notification.
+type Watcher struct {
+	C chan struct{}
+
+	path     string
+	poll     time.Duration
+	debounce time.Duration
+	stop     chan struct{}
+	now      func() time.Time // injectable for tests
+}
+
+// New creates a Watcher for path. Zero poll/debounce use the defaults.
+func New(path string, poll, debounce time.Duration) *Watcher {
+	if poll <= 0 {
+		poll = DefaultPoll
+	}
+	if debounce < 0 {
+		debounce = DefaultDebounce
+	}
+	return &Watcher{
+		C:        make(chan struct{}, 1),
+		path:     path,
+		poll:     poll,
+		debounce: debounce,
+		stop:     make(chan struct{}),
+		now:      time.Now,
+	}
+}
+
+// Start begins polling in a background goroutine.
+func (w *Watcher) Start() {
+	go w.loop()
+}
+
+// Stop ends polling. Safe to call once.
+func (w *Watcher) Stop() {
+	close(w.stop)
+}
+
+func (w *Watcher) loop() {
+	last := statSig(w.path)
+	var pending *sig
+	var pendingSince time.Time
+
+	ticker := time.NewTicker(w.poll)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-w.stop:
+			return
+		case <-ticker.C:
+			cur := statSig(w.path)
+			if pending != nil {
+				if !cur.equal(*pending) {
+					// Still changing; reset the debounce window.
+					p := cur
+					pending = &p
+					pendingSince = w.now()
+					continue
+				}
+				if w.now().Sub(pendingSince) >= w.debounce {
+					last = cur
+					pending = nil
+					w.emit()
+				}
+				continue
+			}
+			if !cur.equal(last) {
+				p := cur
+				pending = &p
+				pendingSince = w.now()
+			}
+		}
+	}
+}
+
+func (w *Watcher) emit() {
+	select {
+	case w.C <- struct{}{}:
+	default: // a notification is already pending; coalesce.
+	}
+}

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -1,0 +1,83 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStatSigChange(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.md")
+	if err := os.WriteFile(p, []byte("a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s1 := statSig(p)
+	if !s1.exists {
+		t.Fatal("expected file to exist")
+	}
+
+	// Size change.
+	if err := os.WriteFile(p, []byte("abc"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s2 := statSig(p)
+	if s1.equal(s2) {
+		t.Error("size change should not be equal")
+	}
+
+	// Missing file.
+	if err := os.Remove(p); err != nil {
+		t.Fatal(err)
+	}
+	s3 := statSig(p)
+	if s3.exists {
+		t.Error("removed file should not exist")
+	}
+	if s2.equal(s3) {
+		t.Error("existing vs missing should not be equal")
+	}
+}
+
+func TestStatSigSameContentSameSig(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.md")
+	if err := os.WriteFile(p, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a := statSig(p)
+	b := statSig(p)
+	if !a.equal(b) {
+		t.Error("two stats of an unchanged file should be equal")
+	}
+}
+
+func TestWatcherEmitsOnChange(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.md")
+	if err := os.WriteFile(p, []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Fast poll/debounce for a quick test.
+	w := New(p, 10*time.Millisecond, 10*time.Millisecond)
+	w.Start()
+	defer w.Stop()
+
+	// No change yet -> no emit.
+	select {
+	case <-w.C:
+		t.Fatal("unexpected emit before any change")
+	case <-time.After(60 * time.Millisecond):
+	}
+
+	if err := os.WriteFile(p, []byte("v2 longer"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-w.C:
+		// good
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected an emit after the file changed")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `less`-style pager, Mermaid theming, and a live-reload watch mode, and makes line-by-line scrolling + terminal-aware theming the defaults.

### Pager: new `less` mode (now the default)
- Scrolls a **line at a time** (`j`/`k`, arrow keys, mouse wheel) instead of `more`'s page jumps, plus half-page (`d`/`u`), page (`space`/`b`), `g`/`G` top/bottom, and `/` `?` `n` `N` search.
- On **Kitty-graphics terminals (Kitty, Ghostty)**, inline Mermaid diagrams scroll **smoothly**: scroll position is tracked in display rows and each frame emits a vertically-cropped Kitty placement for the visible slice of an image, so diagrams scroll partially off-screen like text instead of popping in/out. iTerm2/sixel keep the existing atomic behavior.
- Redraws use **synchronized output (DEC mode 2026)**, with input coalescing and no-op-repaint skipping, to eliminate flicker on fast key-repeat and mouse scrolling.

### Mermaid: `mermaid.theme` config (default `auto`)
- Applies a Mermaid theme to inline images **and** `--pdf` export: `auto`, `light`/`default`, `dark`, `forest`, `neutral`, `base`.
- `auto` queries the terminal background via **OSC 11** and renders dark diagrams on a dark background, light otherwise. Falls back to light when the background can't be determined (e.g. PDF export to a file).

### Watch mode (`--watch`)
- Watches the input file and refreshes the pager in place when it changes, preserving scroll position — for an edit-in-one-pane / preview-in-another workflow.
- Polls mtime+size with a debounce (coalescing rapid saves). The pager loop becomes event-driven: a goroutine feeds terminal bytes to a channel and the loop selects over keystrokes + a reload signal, so the view refreshes without a keypress. Diagrams re-render on change.
- `--watch` / `--no-watch` flags and a `pager.watch` config option, **off by default**. Gated to a file argument rendered to a TTY; otherwise renders once with a note.

### Defaults & docs
- Default `pager.mode` is now `less` (was `more`); default `mermaid.theme` is `auto`.
- README documents `pager.mode`, `pager.watch`, and `mermaid.theme`.

## Behavior change
The default pager changes from `more` to `less`. Users who prefer the old behavior can set `{"pager": {"mode": "more"}}`. `vim` mode is unchanged.

## Testing
- New unit tests: Kitty crop pixel math, row-scroll/segment math and search, OSC 11 color parsing + luminance threshold, theme resolution, watcher change-detection + debounce, reload scroll preservation, and config defaults.
- `go build ./...`, `go vet ./...`, and the full `go test ./...` suite (including the Chrome-backed Mermaid tests) pass, plus `-race` on the watch/pager packages.

## Notes
- Smooth image scrolling and watch require the Kitty graphics protocol for inline diagrams; other terminals fall back gracefully.
- The first inline-diagram render adds a one-time ~200ms terminal background query (only when a document contains diagrams).
- Watch detects the terminal background via stdin and is gated to a file argument, so `cat foo.md | glowm --watch` does not watch.
